### PR TITLE
Handle \r\n in SGF files

### DIFF
--- a/src/wagner/stephanie/lizzie/rules/SGFParser.java
+++ b/src/wagner/stephanie/lizzie/rules/SGFParser.java
@@ -117,7 +117,7 @@ public class SGFParser {
                 if (inTag) {
                     tagContentBuilder.append(c);
                 } else {
-                    if (c != '\n' && c != '\t' && c != ' ') {
+                    if (c != '\n' && c != '\r' && c != '\t' && c != ' ') {
                         tagBuilder.append(c);
                     }
                 }


### PR DESCRIPTION
Fixes SGF-parsing bug where Lizzie would drop moves following the Windows linebreak sequence `\r\n`, such as output by SmartGo Kifu.