### PR TITLE
Highlight next move

### DIFF
--- a/src/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -388,6 +388,18 @@ public class BoardRenderer {
                     }
                 }
             }
+
+            int[] nextMove = Lizzie.board.getNextMove();
+            if (nextMove != null) {
+                if (Lizzie.board.getData().blackToPlay) {
+                    g.setColor(Color.BLACK);
+                } else {
+                    g.setColor(Color.WHITE);
+                }
+                int moveX = x + scaledMargin + squareLength * nextMove[0];
+                int moveY = y + scaledMargin + squareLength * nextMove[1];
+                drawCircle(g, moveX, moveY, stoneRadius + 1); // slightly outside best move circle
+            }
         }
     }
 

--- a/src/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/wagner/stephanie/lizzie/rules/Board.java
@@ -317,6 +317,15 @@ public class Board {
     }
 
     /**
+     * get the move played in this position
+     *
+     * @return the next move, if any
+     */
+    public int[] getNextMove() {
+        return history.getNextMove();
+    }
+
+    /**
      * get current board move number
      *
      * @return the int array corresponding to the current board move number

--- a/src/wagner/stephanie/lizzie/rules/BoardHistoryList.java
+++ b/src/wagner/stephanie/lizzie/rules/BoardHistoryList.java
@@ -79,6 +79,14 @@ public class BoardHistoryList {
         return head.getData().lastMove;
     }
 
+    public int[] getNextMove() {
+        BoardData next = getNext();
+        if (next == null)
+            return null;
+        else
+            return next.lastMove;
+    }
+
     public Stone getLastMoveColor() {
         return head.getData().lastMoveColor;
     }


### PR DESCRIPTION
Implements the feature request of #52. The next move of the game (if any) is circled in black or white, depending on the player, slightly outside the red circle of Leela Zero's top move so that they are visible independently. See if you like it.