### PR TITLE
Don't react to parentheses inside tags

### DIFF
--- a/src/wagner/stephanie/lizzie/rules/SGFParser.java
+++ b/src/wagner/stephanie/lizzie/rules/SGFParser.java
@@ -65,12 +65,16 @@ public class SGFParser {
             }
             switch (c) {
             case '(':
-                subTreeDepth += 1;
+                if (!inTag) {
+                    subTreeDepth += 1;
+                }
                 break;
             case ')':
-                subTreeDepth -= 1;
-                if (isMultiGo) {
-                    return true;
+                if (!inTag) {
+                    subTreeDepth -= 1;
+                    if (isMultiGo) {
+                        return true;
+                    }
                 }
                 break;
             case '[':


### PR DESCRIPTION
Fixes a bug where parentheses inside tags (notably comments) would cause the SGFParser to exit early.