### PR TITLE
Start at beginning of game after loading SGF file

### DIFF
--- a/src/wagner/stephanie/lizzie/rules/SGFParser.java
+++ b/src/wagner/stephanie/lizzie/rules/SGFParser.java
@@ -124,6 +124,9 @@ public class SGFParser {
             }
         }
 
+        // Rewind to game start
+        while (Lizzie.board.previousMove());
+
         return true;
     }
 


### PR DESCRIPTION
Implements one request from issue #32, which I wanted as well: when an SGF file is loaded, we start at the beginning of the game, not the end.