### PR TITLE
Remember variation tree, easily return to main trunk

### DIFF
--- a/src/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/wagner/stephanie/lizzie/rules/Board.java
@@ -101,7 +101,7 @@ public class Board {
                 Lizzie.leelaz.sendCommand("genmove " + (history.isBlacksTurn()? "W" : "B"));
 
             // update history with pass
-            history.add(newState);
+            history.addOrGoto(newState);
 
             Lizzie.frame.repaint();
         }
@@ -185,7 +185,7 @@ public class Board {
             }
 
             // update history with this coordinate
-            history.add(newState);
+            history.addOrGoto(newState);
 
             Lizzie.frame.repaint();
         }
@@ -359,6 +359,14 @@ public class Board {
 
     public BoardHistoryList getHistory() {
         return history;
+    }
+
+    /**
+     * Clears all history and starts over.
+     */
+    public void clear() {
+        while (previousMove());
+        history.clear();
     }
 
     /**

--- a/src/wagner/stephanie/lizzie/rules/BoardHistoryList.java
+++ b/src/wagner/stephanie/lizzie/rules/BoardHistoryList.java
@@ -16,12 +16,23 @@ public class BoardHistoryList {
     }
 
     /**
+     * Clear history.
+     */
+    public void clear() {
+        head.clear();
+    }
+
+    /**
      * Add new data after head. Overwrites any data that may have been stored after head.
      *
      * @param data the data to add
      */
     public void add(BoardData data) {
         head = head.add(new BoardHistoryNode(data));
+    }
+
+    public void addOrGoto(BoardData data) {
+        head = head.addOrGoto(data);
     }
 
     /**

--- a/src/wagner/stephanie/lizzie/rules/BoardHistoryNode.java
+++ b/src/wagner/stephanie/lizzie/rules/BoardHistoryNode.java
@@ -49,13 +49,10 @@ public class BoardHistoryNode {
      */
     public BoardHistoryNode addOrGoto(BoardData data) {
         for (int i = 0; i < nexts.size(); i++) {
-            System.out.printf("Trying next %d/%d\n", i, nexts.size());
             if (nexts.get(i).data.zobrist.equals(data.zobrist)) {
-                System.out.println("Found it");
                 return nexts.get(i);
             }
         }
-        System.out.println("Had to add a node");
         BoardHistoryNode node = new BoardHistoryNode(data);
         nexts.add(node);
         node.previous = this;

--- a/src/wagner/stephanie/lizzie/rules/BoardHistoryNode.java
+++ b/src/wagner/stephanie/lizzie/rules/BoardHistoryNode.java
@@ -1,11 +1,12 @@
 package wagner.stephanie.lizzie.rules;
+import java.util.ArrayList;
 
 /**
  * Node structure for a special doubly linked list
  */
 public class BoardHistoryNode {
     private BoardHistoryNode previous;
-    private BoardHistoryNode next;
+    private ArrayList<BoardHistoryNode> nexts;
 
     private BoardData data;
 
@@ -14,8 +15,15 @@ public class BoardHistoryNode {
      */
     public BoardHistoryNode(BoardData data) {
         previous = null;
-        next = null;
+        nexts = new ArrayList<BoardHistoryNode>();
         this.data = data;
+    }
+
+    /**
+     * Remove all subsequent nodes.
+     */
+    public void clear() {
+        nexts.clear();
     }
 
     /**
@@ -25,7 +33,31 @@ public class BoardHistoryNode {
      * @return the node that was just set
      */
     public BoardHistoryNode add(BoardHistoryNode node) {
-        next = node;
+        nexts.clear();
+        nexts.add(node);
+        node.previous = this;
+
+        return node;
+    }
+
+    /**
+     * If we already have a next node with the same BoardData, move to it,
+     * otherwise add it and move to it.
+     *
+     * @param node the node following this one
+     * @return the node that was just set
+     */
+    public BoardHistoryNode addOrGoto(BoardData data) {
+        for (int i = 0; i < nexts.size(); i++) {
+            System.out.printf("Trying next %d/%d\n", i, nexts.size());
+            if (nexts.get(i).data.zobrist.equals(data.zobrist)) {
+                System.out.println("Found it");
+                return nexts.get(i);
+            }
+        }
+        System.out.println("Had to add a node");
+        BoardHistoryNode node = new BoardHistoryNode(data);
+        nexts.add(node);
         node.previous = this;
 
         return node;
@@ -43,6 +75,10 @@ public class BoardHistoryNode {
     }
 
     public BoardHistoryNode next() {
-        return next;
+        if (nexts.size() == 0) {
+            return null;
+        } else {
+            return nexts.get(0);
+        }
     }
 }

--- a/src/wagner/stephanie/lizzie/rules/SGFParser.java
+++ b/src/wagner/stephanie/lizzie/rules/SGFParser.java
@@ -7,8 +7,7 @@ import java.io.*;
 public class SGFParser {
     public static boolean load(String filename) throws IOException {
         // Clear the board
-        while (Lizzie.board.previousMove())
-            ;
+        Lizzie.board.clear();
 
         File file = new File(filename);
         if (!file.exists() || !file.canRead()) {


### PR DESCRIPTION
This partially implements @ProLeela's request in issue #32.

From a user standpoint, Lizzie now remembers the entire variation tree that has been explored. Right-arrow always chooses the original move played in the current position (this is the move from the SGF file if it exists), and that is the move displayed with a black or white outline. This means that you can now explore a variation, left-arrow back to the main trunk, and then continue with the loaded game (previously, the rest of the loaded game would be blown away).

From a coder standpoint, this code should probably be examined a little more closely than my other pull requests. I'm not a Java programmer and don't know whether my use of `ArrayList`s to store child `BoardHistoryNode`s is inefficient with respect to speed or memory. I don't do any cleanup and am assuming that Java's GC just takes care of freeing everything as necessary.