### PR TITLE
add support for pass moves.

### DIFF
--- a/src/wagner/stephanie/lizzie/rules/SGFParser.java
+++ b/src/wagner/stephanie/lizzie/rules/SGFParser.java
@@ -130,29 +130,42 @@ public class SGFParser {
     public static boolean save(String filename) throws IOException {
         FileOutputStream fp = new FileOutputStream(filename);
         OutputStreamWriter writer = new OutputStreamWriter(fp);
-        StringBuilder builder = new StringBuilder(String.format("(;KM[7.5]AP[Lizzie: %s]", Lizzie.lizzieVersion));
-        BoardHistoryList history = Lizzie.board.getHistory();
-        while (history.previous() != null) ;
-        BoardData data = null;
-        while ((data = history.next()) != null) {
-            StringBuilder tag = new StringBuilder(";");
-            if (data.lastMoveColor.equals(Stone.BLACK)) {
-                tag.append("B");
-            } else if (data.lastMoveColor.equals(Stone.WHITE)) {
-                tag.append("W");
-            } else {
-                return false;
+
+        try
+        {
+            // add SGF header
+            StringBuilder builder = new StringBuilder(String.format("(;KM[7.5]AP[Lizzie: %s]", Lizzie.lizzieVersion));
+
+            // move to the first move
+            BoardHistoryList history = Lizzie.board.getHistory();
+            while (history.previous() != null);
+
+            // replay moves, and convert them to tags.
+            // *  format: ";B[xy]" or ";W[xy]"
+            // *  with 'xy' = coordinates ; or 'tt' for pass.
+            BoardData data;
+            while ((data = history.next()) != null) {
+
+                String stone;
+                if (Stone.BLACK.equals(data.lastMoveColor)) stone = "B";
+                else if (Stone.WHITE.equals(data.lastMoveColor)) stone = "W";
+                else continue;
+
+                char x = data.lastMove == null ? 't' : (char) (data.lastMove[0] + 'a');
+                char y = data.lastMove == null ? 't' : (char) (data.lastMove[1] + 'a');
+
+                builder.append(String.format(";%s[%c%c]", stone, x, y));
             }
-            char x = (char) data.lastMove[0], y = (char) data.lastMove[1];
-            x += 'a';
-            y += 'a';
-            tag.append(String.format("[%c%c]", x, y));
-            builder.append(tag);
+
+            // close file
+            builder.append(')');
+            writer.append(builder.toString());
         }
-        builder.append(')');
-        writer.append(builder.toString());
-        writer.close();
-        fp.close();
+        finally
+        {
+            writer.close();
+            fp.close();
+        }
         return true;
     }
 }


### PR DESCRIPTION
I encountered a NullPointerException when I tried to save an SGF file.
The reason was that LeeLa played a pass move.

Pass moves should be in format ";B[tt]" according to the SGF standard.

I changed a couple of things to this method:
1) a try-finally mechanism assures that the file is always properly closed.
2) if no color is found, there is no longer a "return" statement, but a "continue" statement.
3) support for the pass moves.
4) some cosmetics: line-breaks/comments/eliminated a StringBuilder.

Everything is tested and works great :).