### PR TITLE
Widen the margin of board so that the stones will not hide coordinates

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -21,7 +21,8 @@ import java.util.List;
 import java.util.Map;
 
 public class BoardRenderer {
-    private static final double MARGIN = 0.06; // percentage of the boardLength to offset before drawing black lines
+    private static final double MARGIN = 0.03; // percentage of the boardLength to offset before drawing black lines
+    private static final double MARGIN_WITH_COORDINATES = 0.06;
     private static final double STARPOINT_DIAMETER = 0.015;
 
     private int x, y;
@@ -444,10 +445,11 @@ public class BoardRenderer {
         int availableLength;
 
         // decrease boardLength until the availableLength will result in square board intersections
+        double margin = Lizzie.frame.showCoordinates ? MARGIN_WITH_COORDINATES : MARGIN;
         boardLength++;
         do {
             boardLength--;
-            scaledMargin = (int) (MARGIN * boardLength);
+            scaledMargin = (int) (margin * boardLength);
             availableLength = boardLength - 2 * scaledMargin;
         }
         while (!((availableLength - 1) % (Board.BOARD_SIZE - 1) == 0));

--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 public class BoardRenderer {
-    private static final double MARGIN = 0.03; // percentage of the boardLength to offset before drawing black lines
+    private static final double MARGIN = 0.06; // percentage of the boardLength to offset before drawing black lines
     private static final double STARPOINT_DIAMETER = 0.015;
 
     private int x, y;


### PR DESCRIPTION
Lizzie now can show the coordinates to help place or record moves by pressing the shortcut "C". But I find that if a stone was placed on the edge of the board(that is, Row 1 or 19, or Column A or T), it would hide the coordinate texts, because the coordinate texts are too close to the board lines.
I managed to find a simple and quick solution for this: just increased the value of `BoardRenderer.MARGIN` from `0.03` to `0.06`, so that there would be enough room between the coordinate texts and the stones and the stones would not hide the texts no longer.