### PR TITLE
Display winrate in separate box when in pondering mode.

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/analysis/Branch.java
+++ b/src/main/java/wagner/stephanie/lizzie/analysis/Branch.java
@@ -1,5 +1,6 @@
 package wagner.stephanie.lizzie.analysis;
 
+import wagner.stephanie.lizzie.Lizzie;
 import wagner.stephanie.lizzie.rules.Board;
 import wagner.stephanie.lizzie.rules.BoardData;
 import wagner.stephanie.lizzie.rules.Stone;
@@ -20,7 +21,8 @@ public class Branch {
         Stone[] stones = board.getStones().clone();
         Zobrist zobrist = board.getData().zobrist == null ? null : board.getData().zobrist.clone();
 
-        this.data = new BoardData(stones, lastMove, lastMoveColor, blackToPlay, zobrist, moveNumber, moveNumberList);
+        // Dont care about winrate for branch
+        this.data = new BoardData(stones, lastMove, lastMoveColor, blackToPlay, zobrist, moveNumber, moveNumberList ,0.0);
 
         for (int i = 0; i < variation.size(); i++) {
             int[] coord = Board.convertNameToCoordinates(variation.get(i));

--- a/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
+++ b/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
@@ -253,4 +253,17 @@ public class Leelaz {
     public boolean isPondering() {
         return isPondering;
     }
+
+    /*
+     * Return the best win rate, returns negative number if no analysis is available
+     */
+    public double getBestWinrate() {
+        double maxWinrate = -100;
+
+        for (MoveData move : bestMoves) {
+            if (move.winrate > maxWinrate)
+                maxWinrate = move.winrate;
+        }
+        return maxWinrate;
+    }
 }

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -3,6 +3,7 @@ package wagner.stephanie.lizzie.gui;
 import com.jhlabs.image.GaussianFilter;
 import wagner.stephanie.lizzie.Lizzie;
 import wagner.stephanie.lizzie.rules.Board;
+import wagner.stephanie.lizzie.rules.BoardData;
 import wagner.stephanie.lizzie.rules.SGFParser;
 
 import javax.imageio.ImageIO;
@@ -181,6 +182,15 @@ public class LizzieFrame extends JFrame {
             boardRenderer.setBoardLength(maxSize);
             boardRenderer.draw(g);
 
+            // Todo: Make board move over when there is no space beside the board
+            if (Lizzie.leelaz.isPondering()) {
+                // boardX equals width of space on each side
+                int statx = (int) (boardX*1.05 + maxSize);
+                int staty = boardY + maxSize/4;
+                int statw = (int)(boardX*0.8);
+                int stath = maxSize/3;
+                drawMoveStatistics(g, statx, staty, statw, stath);
+            }
 
             // cleanup
             g.dispose();
@@ -272,6 +282,66 @@ public class LizzieFrame extends JFrame {
         g.setColor(Color.WHITE);
         g.setFont(font);
         g.drawString(commandString, showCommandsX+2*strokeRadius, showCommandsY + font.getSize());
+    }
+
+    private void drawMoveStatistics(Graphics2D g, int posX, int posY, int width, int height) {
+
+        BoardData bd = Lizzie.board.getData();
+
+        double lastWR = bd.winrate;
+        double curWR = Lizzie.leelaz.getBestWinrate();
+        if (curWR < 0) {
+            curWR = 100 - lastWR;
+        }
+        double whiteWR, blackWR;
+        if (bd.blackToPlay) {
+            blackWR = curWR;
+        } else {
+            blackWR = 100 - curWR;
+        }
+        whiteWR = 100 - blackWR;
+
+        // Background rectangle
+        g.setColor(new Color(0, 0, 0, 130));
+        g.fillRect(posX, posY, width, height);
+
+        // Title
+        Font font = new Font("Open Sans", Font.PLAIN, (int) (Math.min(width, height) * 0.09));
+        int strokeRadius = 2;
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g.setColor(Color.WHITE);
+        g.setFont(font);
+        g.drawString("Winrate", posX+2*strokeRadius, posY + font.getSize());
+
+        // Last move
+        font = new Font("Open Sans", Font.PLAIN, (int) (Math.min(width, height) * 0.07));
+        g.setFont(font);
+        if (lastWR < 0)
+            // In case leelaz didnt have time to calculate
+            g.drawString("Last move: ?%", posX+2*strokeRadius, posY + height - font.getSize());
+        else
+            g.drawString(String.format("Last move: %.1f%%", 100 - lastWR - curWR), posX+2*strokeRadius, posY + height - font.getSize());
+
+
+        int maxBarHeight = (int) (height*0.6);
+        int barHeightB = (int) (blackWR*maxBarHeight/100);
+        int barHeightW = (int) (whiteWR*maxBarHeight/100);
+        int barPosxB = posX + width/5;
+        int barPosxW = posX + width*3/5;
+        int barPosyB = (int)(posY*1.2 + maxBarHeight - barHeightB);
+        int barPosyW = (int)(posY*1.2 + maxBarHeight - barHeightW);
+        int barWidth = width/5;
+
+        // Draw winrate bars
+        g.fillRect(barPosxW, barPosyW, barWidth, barHeightW);
+        g.setColor(Color.BLACK);
+        g.fillRect(barPosxB, barPosyB, barWidth, barHeightB);
+
+        // Show percentage on bars
+        g.drawString(String.format("%.1f", whiteWR), barPosxW + 2*strokeRadius, barPosyW + barHeightW - 2*strokeRadius);
+        g.setColor(Color.WHITE);
+        g.drawString(String.format("%.1f", blackWR), barPosxB + 2*strokeRadius, barPosyB + barHeightB - 2*strokeRadius);
+
     }
 
     /**

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -289,6 +289,7 @@ public class LizzieFrame extends JFrame {
         BoardData bd = Lizzie.board.getData();
 
         double lastWR = bd.winrate;
+        double lastBWR = lastWR;
         double curWR = Lizzie.leelaz.getBestWinrate();
         if (curWR < 0) {
             curWR = 100 - lastWR;
@@ -296,6 +297,7 @@ public class LizzieFrame extends JFrame {
         double whiteWR, blackWR;
         if (bd.blackToPlay) {
             blackWR = curWR;
+            lastBWR = 100 - lastWR;
         } else {
             blackWR = 100 - curWR;
         }
@@ -329,19 +331,22 @@ public class LizzieFrame extends JFrame {
         int barPosxB = posX + width/5;
         int barPosxW = posX + width*3/5;
         int barPosyB = (int)(posY*1.2 + maxBarHeight - barHeightB);
-        int barPosyW = (int)(posY*1.2 + maxBarHeight - barHeightW);
+        int barPosyW = (int)(posY*1.2);
         int barWidth = width/5;
+        int lastLine = (int)(posY*1.2 + maxBarHeight - lastBWR*maxBarHeight/100);
 
         // Draw winrate bars
-        g.fillRect(barPosxW, barPosyW, barWidth, barHeightW);
+        g.fillRect(barPosxB, barPosyW, barWidth, barHeightW);
         g.setColor(Color.BLACK);
         g.fillRect(barPosxB, barPosyB, barWidth, barHeightB);
 
         // Show percentage on bars
-        g.drawString(String.format("%.1f", whiteWR), barPosxW + 2*strokeRadius, barPosyW + barHeightW - 2*strokeRadius);
+        g.drawString(String.format("%.1f", whiteWR), barPosxB + 2*strokeRadius, barPosyW + 2*strokeRadius + font.getSize());
         g.setColor(Color.WHITE);
         g.drawString(String.format("%.1f", blackWR), barPosxB + 2*strokeRadius, barPosyB + barHeightB - 2*strokeRadius);
 
+        g.setColor(Color.RED);
+        g.drawLine(barPosxB , lastLine, barPosxB + barWidth, lastLine);
     }
 
     /**

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -40,6 +40,7 @@ public class LizzieFrame extends JFrame {
             "ctrl|undo/redo 10 moves",
     };
     private static BoardRenderer boardRenderer;
+    private static WinrateGraph winrateGraph;
 
     private final BufferStrategy bs;
 
@@ -67,6 +68,7 @@ public class LizzieFrame extends JFrame {
         super("Lizzie - Leela Zero Interface");
 
         boardRenderer = new BoardRenderer();
+        winrateGraph = new WinrateGraph();
 
         // on 1080p screens in Windows, this is a good width/height. removing a default size causes problems in Linux
         setSize(657, 687);
@@ -191,6 +193,8 @@ public class LizzieFrame extends JFrame {
                 int stath = maxSize/3;
                 drawMoveStatistics(g, statx, staty, statw, stath);
             }
+            winrateGraph.draw(g, 0,maxSize/3, boardX, maxSize/3);
+
 
             // cleanup
             g.dispose();
@@ -286,16 +290,20 @@ public class LizzieFrame extends JFrame {
 
     private void drawMoveStatistics(Graphics2D g, int posX, int posY, int width, int height) {
 
-        BoardData bd = Lizzie.board.getData();
 
-        double lastWR = bd.winrate;
+        double lastWR;
+        if (Lizzie.board.getData().moveNumber == 0)
+            lastWR = 50;
+        else
+            lastWR = Lizzie.board.getHistory().getPrevious().winrate;
         double lastBWR = lastWR;
+
         double curWR = Lizzie.leelaz.getBestWinrate();
         if (curWR < 0) {
             curWR = 100 - lastWR;
         }
         double whiteWR, blackWR;
-        if (bd.blackToPlay) {
+        if (Lizzie.board.getData().blackToPlay) {
             blackWR = curWR;
             lastBWR = 100 - lastWR;
         } else {

--- a/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
@@ -1,0 +1,67 @@
+package wagner.stephanie.lizzie.gui;
+
+import wagner.stephanie.lizzie.Lizzie;
+import wagner.stephanie.lizzie.rules.BoardHistoryNode;
+
+import java.awt.*;
+
+public class WinrateGraph {
+
+    private int DOT_RADIUS = 4;
+
+    public void draw(Graphics2D g, int posx, int posy, int width, int height)
+    {
+        BoardHistoryNode curMove = Lizzie.board.getHistory().getCurrentHistoryNode();
+        BoardHistoryNode node = curMove;
+
+        // Background rectangle
+        g.setColor(new Color(0, 0, 0, 130));
+        g.fillRect(posx, posy, width, height);
+        g.setColor(Color.white);
+        g.drawLine(posx, posy + height/2, posx + width, posy + height/2);
+
+
+        // Go to bottom to find number of moves in main line
+        while (node.next() != null) node = node.next();
+        int numMoves = node.getData().moveNumber;
+
+        if (numMoves < 2) return;
+
+        node = curMove;
+        // Go to first move (second node) to start plotting
+        while (node.previous() != null) node = node.previous();
+        node = node.next();
+
+        // Plot
+        width = (int)(width*0.95); // Leave some space after last move
+        double lastWr = 50;
+        int movenum = 1;
+        g.setColor(Color.green);
+        while (node != null)
+        {
+            double wr = node.getData().winrate;
+            if (node == curMove)
+            {
+                double bwr = Lizzie.leelaz.getBestWinrate();
+                if (bwr >= 0) {
+                    wr = bwr;
+                }
+            }
+            if (wr < 0)
+            {
+                wr = 100 - lastWr;
+            }
+            else if (!node.getData().blackToPlay)
+            {
+                wr = 100 - wr;
+            }
+
+            g.drawLine(posx + ((movenum - 1)*width/numMoves), posy + height - (int)(lastWr*height/100), posx + (movenum*width/numMoves), posy + height - (int)(wr*height/100));
+            if (node == curMove)
+                g.fillOval(posx + (movenum*width/numMoves) - DOT_RADIUS, posy + height - (int)(wr*height/100) - DOT_RADIUS, DOT_RADIUS*2, DOT_RADIUS*2);
+            node = node.next();
+            lastWr = wr;
+            movenum++;
+        }
+    }
+}

--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -16,7 +16,7 @@ public class Board {
         boolean blackToPlay = true;
         int[] lastMove = null;
 
-        history = new BoardHistoryList(new BoardData(stones, lastMove, Stone.EMPTY, blackToPlay, new Zobrist(), 0, new int[BOARD_SIZE * BOARD_SIZE]));
+        history = new BoardHistoryList(new BoardData(stones, lastMove, Stone.EMPTY, blackToPlay, new Zobrist(), 0, new int[BOARD_SIZE * BOARD_SIZE], 50));
     }
 
     /**
@@ -93,7 +93,7 @@ public class Board {
             int[] moveNumberList = history.getMoveNumberList().clone();
 
             // build the new game state
-            BoardData newState = new BoardData(stones, null, color, color.equals(Stone.WHITE), zobrist, moveNumber, moveNumberList);
+            BoardData newState = new BoardData(stones, null, color, color.equals(Stone.WHITE), zobrist, moveNumber, moveNumberList, 0);
 
             // update leelaz with pass
             Lizzie.leelaz.playMove(color, "pass");
@@ -170,7 +170,9 @@ public class Board {
             }
 
             // build the new game state
-            BoardData newState = new BoardData(stones, lastMove, color, color.equals(Stone.WHITE), zobrist, moveNumber, moveNumberList);
+            double winrate = Lizzie.leelaz.getBestWinrate();
+
+            BoardData newState = new BoardData(stones, lastMove, color, color.equals(Stone.WHITE), zobrist, moveNumber, moveNumberList, winrate);
 
             // don't make this coordinate if it is suicidal or violates superko
             if (isSuicidal || history.violatesSuperko(newState))
@@ -340,6 +342,8 @@ public class Board {
     public boolean nextMove() {
         synchronized (this) {
             if (history.next() != null) {
+                // Update win rate statistics
+                history.getData().winrate = Lizzie.leelaz.getBestWinrate();
                 // update leelaz board position, before updating to next node
                 if (history.getData().lastMove == null) {
                     Lizzie.leelaz.playMove(history.getLastMoveColor(), "pass");

--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -126,6 +126,16 @@ public class Board {
             if (!isValid(x, y) || history.getStones()[getIndex(x, y)] != Stone.EMPTY)
                 return;
 
+            // Update winrate
+            double wr = Lizzie.leelaz.getBestWinrate();
+
+            if (wr >= 0)
+            {
+                history.getData().winrate = wr;
+            }
+            double nextWinrate = -100;
+            if (history.getData().winrate > 0) nextWinrate = 100 - history.getData().winrate;
+
             // check to see if this coordinate is being replayed in history
             BoardData next = history.getNext();
             if (next != null && next.lastMove != null && next.lastMove[0] == x && next.lastMove[1] == y) {
@@ -169,10 +179,7 @@ public class Board {
                 }
             }
 
-            // build the new game state
-            double winrate = Lizzie.leelaz.getBestWinrate();
-
-            BoardData newState = new BoardData(stones, lastMove, color, color.equals(Stone.WHITE), zobrist, moveNumber, moveNumberList, winrate);
+            BoardData newState = new BoardData(stones, lastMove, color, color.equals(Stone.WHITE), zobrist, moveNumber, moveNumberList, nextWinrate);
 
             // don't make this coordinate if it is suicidal or violates superko
             if (isSuicidal || history.violatesSuperko(newState))
@@ -341,9 +348,12 @@ public class Board {
      */
     public boolean nextMove() {
         synchronized (this) {
+            // Update win rate statistics
+            double wr = Lizzie.leelaz.getBestWinrate();
+            if (wr >= 0) {
+                history.getData().winrate = wr;
+            }
             if (history.next() != null) {
-                // Update win rate statistics
-                history.getData().winrate = Lizzie.leelaz.getBestWinrate();
                 // update leelaz board position, before updating to next node
                 if (history.getData().lastMove == null) {
                     Lizzie.leelaz.playMove(history.getLastMoveColor(), "pass");
@@ -378,6 +388,11 @@ public class Board {
      */
     public boolean previousMove() {
         synchronized (this) {
+            // Update win rate statistics
+            double wr  = Lizzie.leelaz.getBestWinrate();
+            if (wr >= 0) {
+                history.getData().winrate = wr;
+            }
             if (history.previous() != null) {
                 Lizzie.leelaz.undo();
                 Lizzie.frame.repaint();

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardData.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardData.java
@@ -10,7 +10,9 @@ public class BoardData {
     public Stone[] stones;
     public Zobrist zobrist;
 
-    public BoardData(Stone[] stones, int[] lastMove, Stone lastMoveColor, boolean blackToPlay, Zobrist zobrist, int moveNumber, int[] moveNumberList) {
+    public double winrate;
+
+    public BoardData(Stone[] stones, int[] lastMove, Stone lastMoveColor, boolean blackToPlay, Zobrist zobrist, int moveNumber, int[] moveNumberList, double winrate) {
         this.moveNumber = moveNumber;
         this.lastMove = lastMove;
         this.moveNumberList = moveNumberList;
@@ -19,5 +21,7 @@ public class BoardData {
         this.lastMoveColor = lastMoveColor;
         this.stones = stones;
         this.zobrist = zobrist;
+
+        this.winrate = winrate;
     }
 }

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
@@ -76,6 +76,18 @@ public class BoardHistoryList {
     }
 
     /**
+     * Does not change the pointer position
+     *
+     * @return the data stored at the previous index. null if not present
+     */
+    public BoardData getPrevious() {
+        if (head.previous() == null)
+            return null;
+        else
+            return head.previous().getData();
+    }
+
+    /**
      * @return the data of the current node
      */
     public BoardData getData() {
@@ -117,6 +129,8 @@ public class BoardHistoryList {
     public int[] getMoveNumberList() {
         return head.getData().moveNumberList;
     }
+
+    public BoardHistoryNode getCurrentHistoryNode() { return head; }
 
     /**
      * @param data the board position to check against superko


### PR DESCRIPTION
I added a winrate with bars that show black and whites winning chance, and more importantly, the change in this for the last move. This makes it easier to spot when you make a mistake (large negative change in win chance) and how "big" the mistake was. I considered adding color coding (orange for medium mistake, red for big mistake), but didn't add this now.

I didn't ask or make a feature request first, but I think this is useful.

![image](https://user-images.githubusercontent.com/38073282/38438054-a2f935d6-39d9-11e8-873f-e64531d5bafa.png)
