### PR TITLE
Implemented Copy SGF to clipboard and paste SGF from clipboard

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -84,6 +84,16 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
 
     @Override
     public void keyPressed(KeyEvent e) {
+        // Some combo keys should be processed first
+        if ((e.getKeyCode() == KeyEvent.VK_C && (e.getModifiers() & KeyEvent.ALT_MASK) != 0)) {
+            // Alt + C -- Copy sgf to clipboard
+            Lizzie.frame.copySgf();
+            return;
+        } else if ((e.getKeyCode() == KeyEvent.VK_V && (e.getModifiers() & KeyEvent.ALT_MASK) != 0)) {
+            // Alt + V -- Paste sgf from clipboard
+            Lizzie.frame.pasteSgf();
+            return;
+        }
 
         int movesToAdvance = 1; // number of moves to advance if control is held down
         switch (e.getKeyCode()) {

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -9,6 +9,10 @@ import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferStrategy;
@@ -33,6 +37,8 @@ public class LizzieFrame extends JFrame {
             "m|show/hide move number",
             "o|open SGF",
             "s|save SGF",
+            "alt-c|copy SGF to clipboard",
+            "alt-v|paste SGF from clipboard",
             "v|toggle variation display",
             "home|go to start",
             "end|go to end",
@@ -303,5 +309,40 @@ public class LizzieFrame extends JFrame {
 
     public void toggleCoordinates() {
         showCoordinates = !showCoordinates;
+    }
+
+    public void copySgf() {
+        try {
+            // Get sgf content from game
+            String sgfContent = SGFParser.saveToString();
+
+            // Save to clipboard
+            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+            Transferable transferableString = new StringSelection(sgfContent);
+            clipboard.setContents(transferableString, null);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void pasteSgf() {
+        try {
+            String sgfContent = null;
+            // Get string from clipboard
+            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+            Transferable clipboardContents = clipboard.getContents(null);
+            if (clipboardContents != null) {
+                if (clipboardContents.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+                    sgfContent = (String) clipboardContents.getTransferData(DataFlavor.stringFlavor);
+                }
+            }
+
+            // load game contents from sgf string
+            if (sgfContent != null && !sgfContent.isEmpty()) {
+                SGFParser.loadFromString(sgfContent);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/wagner/stephanie/lizzie/rules/SGFParser.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/SGFParser.java
@@ -29,6 +29,13 @@ public class SGFParser {
         return parse(value);
     }
 
+    public static boolean loadFromString(String sgfString) {
+        // Clear the board
+        Lizzie.board.clear();
+
+        return parse(sgfString);
+    }
+
     public static int[] convertSgfPosToCoord(String pos) {
         if (pos.equals("tt") || pos.isEmpty())
             return null;
@@ -142,45 +149,48 @@ public class SGFParser {
         return true;
     }
 
+    public static String saveToString() throws IOException {
+        try (StringWriter writer = new StringWriter()) {
+            saveToStream(writer);
+            return writer.toString();
+        }
+    }
+
     public static boolean save(String filename) throws IOException {
-        FileOutputStream fp = new FileOutputStream(filename);
-        OutputStreamWriter writer = new OutputStreamWriter(fp);
-
-        try
-        {
-            // add SGF header
-            StringBuilder builder = new StringBuilder(String.format("(;KM[7.5]AP[Lizzie: %s]", Lizzie.lizzieVersion));
-
-            // move to the first move
-            BoardHistoryList history = Lizzie.board.getHistory();
-            while (history.previous() != null);
-
-            // replay moves, and convert them to tags.
-            // *  format: ";B[xy]" or ";W[xy]"
-            // *  with 'xy' = coordinates ; or 'tt' for pass.
-            BoardData data;
-            while ((data = history.next()) != null) {
-
-                String stone;
-                if (Stone.BLACK.equals(data.lastMoveColor)) stone = "B";
-                else if (Stone.WHITE.equals(data.lastMoveColor)) stone = "W";
-                else continue;
-
-                char x = data.lastMove == null ? 't' : (char) (data.lastMove[0] + 'a');
-                char y = data.lastMove == null ? 't' : (char) (data.lastMove[1] + 'a');
-
-                builder.append(String.format(";%s[%c%c]", stone, x, y));
-            }
-
-            // close file
-            builder.append(')');
-            writer.append(builder.toString());
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(filename))) {
+            saveToStream(writer);
         }
-        finally
-        {
-            writer.close();
-            fp.close();
-        }
+
         return true;
+    }
+
+    private static void saveToStream(Writer writer) throws IOException {
+        // add SGF header
+        StringBuilder builder = new StringBuilder(String.format("(;KM[7.5]AP[Lizzie: %s]", Lizzie.lizzieVersion));
+
+        // move to the first move
+        BoardHistoryList history = Lizzie.board.getHistory();
+        while (history.previous() != null) ;
+
+        // replay moves, and convert them to tags.
+        // *  format: ";B[xy]" or ";W[xy]"
+        // *  with 'xy' = coordinates ; or 'tt' for pass.
+        BoardData data;
+        while ((data = history.next()) != null) {
+
+            String stone;
+            if (Stone.BLACK.equals(data.lastMoveColor)) stone = "B";
+            else if (Stone.WHITE.equals(data.lastMoveColor)) stone = "W";
+            else continue;
+
+            char x = data.lastMove == null ? 't' : (char) (data.lastMove[0] + 'a');
+            char y = data.lastMove == null ? 't' : (char) (data.lastMove[1] + 'a');
+
+            builder.append(String.format(";%s[%c%c]", stone, x, y));
+        }
+
+        // close file
+        builder.append(')');
+        writer.append(builder.toString());
     }
 }


### PR DESCRIPTION
It is a very nice feature of Lizzie to load SGF from a file and save SGF to a file. But sometimes we would like to import/export a game from/to clipboard. For example, someone may paste the SGF contents of a game to a post and we are interested to the game, or we just want to copy/paste games from/to another game editor. I implemented this feature that allows copies from/pastes to clipboard.
Two new hot keys are added to support the feature, that is, Alt-C and Alt-V, to copy and paste. Because CTRL is already used in other functions. I resort to use Alt key.