### PR TITLE
Added display of variation tree

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -39,6 +39,7 @@ public class LizzieFrame extends JFrame {
             "ctrl|undo/redo 10 moves",
     };
     private static BoardRenderer boardRenderer;
+    private static VariationTree variatonTree;
 
     private final BufferStrategy bs;
 
@@ -66,6 +67,7 @@ public class LizzieFrame extends JFrame {
         super("Lizzie - Leela Zero Interface");
 
         boardRenderer = new BoardRenderer();
+        variatonTree = new VariationTree();
 
         // on 1080p screens in Windows, this is a good width/height. removing a default size causes problems in Linux
         setSize(657, 687);
@@ -181,6 +183,8 @@ public class LizzieFrame extends JFrame {
             boardRenderer.setBoardLength(maxSize);
             boardRenderer.draw(g);
 
+
+            variatonTree.draw(g, maxSize + boardX, 0, maxSize, getHeight());
 
             // cleanup
             g.dispose();

--- a/src/main/java/wagner/stephanie/lizzie/gui/VariationTree.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/VariationTree.java
@@ -1,0 +1,148 @@
+package wagner.stephanie.lizzie.gui;
+
+import wagner.stephanie.lizzie.Lizzie;
+import wagner.stephanie.lizzie.rules.BoardHistoryNode;
+
+import java.awt.*;
+import java.util.ArrayList;
+
+public class VariationTree {
+
+    private int YSPACING = 30;
+    private int XSPACING = 30;
+    private int DOT_DIAM = 11; // Should be odd number
+
+    private ArrayList<Integer> laneUsageList;
+    private BoardHistoryNode curMove;
+
+    public VariationTree()
+    {
+        laneUsageList = new ArrayList<Integer>();
+    }
+
+    private int getDepth(BoardHistoryNode node)
+    {
+        int c = 0;
+        while (node.next() != null)
+        {
+            c++;
+            node = node.next();
+        }
+        return c;
+    }
+
+    public BoardHistoryNode findTop(BoardHistoryNode start)
+    {
+        BoardHistoryNode top = start;
+        while (start.previous() != null)
+        {
+            if (start.previous().next() != start)
+            {
+                top = start.previous();
+            }
+            start = start.previous();
+        }
+        return top;
+    }
+
+    public void drawTree(Graphics2D g, int posx, int posy, int startLane, int maxposy, BoardHistoryNode startNode, int variationNumber, boolean isMain)
+    {
+        if (isMain) g.setColor(Color.black);
+        else g.setColor(Color.gray);
+
+        // Finds depth on leftmost variation of this tree
+        int depth = getDepth(startNode);
+        int lane = startLane;
+        // Figures out how far out too the right (which lane) we have to go not to collide with other variations
+        while (lane < laneUsageList.size() && laneUsageList.get(lane) <= startNode.getData().moveNumber + depth) {
+            // laneUsageList keeps a list of how far down it is to a variation in the different "lanes"
+            laneUsageList.set(lane, startNode.getData().moveNumber - 1);
+            lane++;
+        }
+        if (lane >= laneUsageList.size())
+        {
+                laneUsageList.add(0);
+        }
+        if (variationNumber > 1)
+            laneUsageList.set(lane - 1, startNode.getData().moveNumber - 1);
+        laneUsageList.set(lane, startNode.getData().moveNumber);
+
+        // At this point, lane contains the lane we should use (the main branch is in lane 0)
+
+        BoardHistoryNode cur  = startNode;
+        int curposx = posx + lane*XSPACING;
+        int dotoffset = DOT_DIAM/2;
+
+        // Draw line back to main branch
+        if (lane > 0) {
+            if (lane - startLane > 0 || variationNumber > 1) {
+                // Need a horizontal and an angled line
+                g.drawLine(curposx + dotoffset, posy + dotoffset, curposx + dotoffset - XSPACING, posy + dotoffset - YSPACING);
+                g.drawLine(posx + (startLane - variationNumber )*XSPACING + 2*dotoffset, posy - YSPACING + dotoffset, curposx + dotoffset - XSPACING, posy + dotoffset - YSPACING);
+            } else {
+                // Just an angled line
+                g.drawLine(curposx + dotoffset, posy + dotoffset, curposx + 2*dotoffset - XSPACING, posy + 2*dotoffset - YSPACING);
+            }
+        }
+
+        // Draw all the nodes and lines in this lane (not variations)
+        Color curcolor = g.getColor();
+        if (startNode == curMove) {
+            g.setColor(Color.red);
+        }
+        if (startNode.previous() != null) {
+            g.fillOval(curposx, posy, DOT_DIAM, DOT_DIAM);
+        } else {
+            g.fillRect(curposx, posy, DOT_DIAM, DOT_DIAM);
+        }
+        g.setColor(curcolor);
+
+        // Draw main line
+        while (cur.next() != null && posy + YSPACING < maxposy) {
+            posy += YSPACING;
+            cur = cur.next();
+            if (cur == curMove)  {
+                g.setColor(Color.red);
+            }
+            g.fillOval(curposx , posy, DOT_DIAM, DOT_DIAM);
+            g.setColor(curcolor);
+            g.drawLine(curposx + dotoffset, posy, curposx + dotoffset , posy - YSPACING + 2*dotoffset);
+        }
+        // Now we have drawn all the nodes in this variation, and has reached the bottom of this variation
+        // Move back up, and for each, draw any variations we find
+        while (cur.previous() != null && cur != startNode) {
+            cur = cur.previous();
+            int curwidth = lane;
+            // Draw each variation, uses recursion
+            for (int i = 1; i < cur.allVariants().size(); i++) {
+                curwidth++;
+                // Recursion, depth of recursion will normally not be very deep (one recursion level for every variation that has a variation (sort of))
+                drawTree(g, posx, posy, curwidth, maxposy, cur.allVariants().get(i), i,false);
+            }
+            posy -= YSPACING;
+        }
+    }
+
+    public void draw(Graphics2D g, int posx, int posy, int width, int height) {
+        // Draw white background for now
+        g.setColor(new Color(255, 255, 255, 130));
+        g.fillRect(posx, posy, width, height);
+
+        int middleY = posy + height/2;
+        int xoffset = 30;
+        laneUsageList.clear();
+
+        curMove = Lizzie.board.getHistory().getCurrentHistoryNode();
+
+        // Is current move a variation? If so, find top of variation
+        BoardHistoryNode top = findTop(curMove);
+        int curposy = middleY - YSPACING*(curMove.getData().moveNumber - top.getData().moveNumber);
+        // Go to very top of tree (visible in assigned area)
+        BoardHistoryNode node = top;
+        while  (curposy > posy + YSPACING && node.previous() != null) {
+            node = node.previous();
+            curposy -= YSPACING;
+        }
+        drawTree(g, posx + xoffset, curposy, 0, posy + height, node, 0,true);
+    }
+}

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
@@ -118,6 +118,10 @@ public class BoardHistoryList {
         return head.getData().moveNumberList;
     }
 
+    public BoardHistoryNode getCurrentHistoryNode() {
+        return head;
+    }
+
     /**
      * @param data the board position to check against superko
      * @return whether or not the given position violates the superko rule at the head's state

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryNode.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryNode.java
@@ -78,4 +78,12 @@ public class BoardHistoryNode {
             return nexts.get(0);
         }
     }
+
+    public ArrayList<BoardHistoryNode> allVariants() {
+        if (nexts.size() == 0) {
+            return null;
+        } else {
+            return nexts;
+        }
+    }
 }


### PR DESCRIPTION
I've added a suggestion for showing the variation tree. The algorithm for getting the layout is a bit tricky (might be possible to simplify, this is what I came up with (started fiddling with it yesterday)), so there might still be bugs that get some lines crossed. Let me know if you observe this (a screen capture of the tree is most useful in that scenario).

I've just put the tree on the right side for now. There is no animations or anything, and just 2D drawing, but it's a start. If this would be better to draw a different way (inside some frames/panel or using some library or what not), please feel free to change it (and anything else of course), that should be trivial. It is the layout algorithm that requires a bit of thinking.

In time, the nodes should be clickable, we could see if it is possible to add some color coding (or symbols/icons next to the dots) that shows which moves were bad (according to leelaz) and more.

Known limitations: Does not recenter on the current variation if there isn't enough room on the screen (will fall on the outside).

Currently it looks like this:
![image](https://user-images.githubusercontent.com/38073282/38701010-1442b966-3e9d-11e8-91c1-b6bb29972ce4.png)
