### PR TITLE
Added localization support and Chinese translations

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -18,6 +18,7 @@ import wagner.stephanie.lizzie.rules.Board;
 import wagner.stephanie.lizzie.rules.SGFParser;
 
 import javax.imageio.ImageIO;
+import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
@@ -31,10 +32,7 @@ import java.awt.image.BufferStrategy;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
+import java.util.ResourceBundle;
 
 import wagner.stephanie.lizzie.theme.DefaultTheme;
 
@@ -42,26 +40,28 @@ import wagner.stephanie.lizzie.theme.DefaultTheme;
  * The window used to display the game.
  */
 public class LizzieFrame extends JFrame {
+    private static final ResourceBundle resourceBundle = ResourceBundle.getBundle("l10n.DisplayStrings");
+
     private static final String[] commands = {
-            "n|start game against Leela Zero",
-            "enter|force Leela Zero move",
-            "space|toggle pondering",
-            "left arrow|undo",
-            "right arrow|redo",
-            "right click|undo",
-            "scrollwheel|undo/redo",
-            "c|toggle coordinates",
-            "p|pass",
-            "m|show/hide move number",
-            "i|edit game info",
-            "o|open SGF",
-            "s|save SGF",
-            "alt-c|copy SGF to clipboard",
-            "alt-v|paste SGF from clipboard",
-            "v|toggle variation display",
-            "home|go to start",
-            "end|go to end",
-            "ctrl|undo/redo 10 moves",
+            resourceBundle.getString("LizzieFrame.commands.keyN"),
+            resourceBundle.getString("LizzieFrame.commands.keyEnter"),
+            resourceBundle.getString("LizzieFrame.commands.keySpace"),
+            resourceBundle.getString("LizzieFrame.commands.keyLeftArrow"),
+            resourceBundle.getString("LizzieFrame.commands.keyRightArrow"),
+            resourceBundle.getString("LizzieFrame.commands.rightClick"),
+            resourceBundle.getString("LizzieFrame.commands.mouseWheelScroll"),
+            resourceBundle.getString("LizzieFrame.commands.keyC"),
+            resourceBundle.getString("LizzieFrame.commands.keyP"),
+            resourceBundle.getString("LizzieFrame.commands.keyM"),
+            resourceBundle.getString("LizzieFrame.commands.keyI"),
+            resourceBundle.getString("LizzieFrame.commands.keyO"),
+            resourceBundle.getString("LizzieFrame.commands.keyS"),
+            resourceBundle.getString("LizzieFrame.commands.keyAltC"),
+            resourceBundle.getString("LizzieFrame.commands.keyAltV"),
+            resourceBundle.getString("LizzieFrame.commands.keyV"),
+            resourceBundle.getString("LizzieFrame.commands.keyHome"),
+            resourceBundle.getString("LizzieFrame.commands.keyEnd"),
+            resourceBundle.getString("LizzieFrame.commands.keyControl"),
     };
     private static BoardRenderer boardRenderer;
     private static VariationTree variatonTree;
@@ -74,6 +74,9 @@ public class LizzieFrame extends JFrame {
     public boolean showCoordinates = false;
     public boolean isPlayingAgainstLeelaz = false;
     public boolean playerIsBlack = true;
+
+    // Get the font name in current system locale
+    private String systemDefaultFontName = new JLabel().getFont().getFontName();
 
     static {
         // load fonts
@@ -177,7 +180,7 @@ public class LizzieFrame extends JFrame {
         if (result == JFileChooser.APPROVE_OPTION) {
             File file = chooser.getSelectedFile();
             if (file.exists()) {
-                int ret = JOptionPane.showConfirmDialog(null, "The SGF file already exists, do you want to replace it?", "Warning", JOptionPane.OK_CANCEL_OPTION);
+                int ret = JOptionPane.showConfirmDialog(null, resourceBundle.getString("LizzieFrame.prompt.sgfExists"), "Warning", JOptionPane.OK_CANCEL_OPTION);
                 if (ret == JOptionPane.CANCEL_OPTION) {
                     return;
                 }
@@ -188,7 +191,7 @@ public class LizzieFrame extends JFrame {
             try {
                 SGFParser.save(Lizzie.board, file.getPath());
             } catch (IOException err) {
-                JOptionPane.showConfirmDialog(null, "Failed to save the SGF file.", "Error", JOptionPane.ERROR);
+                JOptionPane.showConfirmDialog(null, resourceBundle.getString("LizzieFrame.prompt.failedToSaveSgf"), "Error", JOptionPane.ERROR);
             }
         }
     }
@@ -208,7 +211,7 @@ public class LizzieFrame extends JFrame {
                 System.out.println(file.getPath());
                 SGFParser.load(file.getPath());
             } catch (IOException err) {
-                JOptionPane.showConfirmDialog(null, "Failed to open the SGF file.", "Error", JOptionPane.ERROR);
+                JOptionPane.showConfirmDialog(null, resourceBundle.getString("LizzieFrame.prompt.failedToOpenSgf"), "Error", JOptionPane.ERROR);
             }
         }
     }
@@ -291,7 +294,7 @@ public class LizzieFrame extends JFrame {
 
         Graphics2D g = (Graphics2D) cachedImage.getGraphics();
         int maxSize = Math.min(getWidth(), getHeight());
-        Font font = new Font("Open Sans", Font.PLAIN, (int) (maxSize * 0.04));
+        Font font = new Font(systemDefaultFontName, Font.PLAIN, (int) (maxSize * 0.04));
         g.setFont(font);
         int lineHeight = (int) (font.getSize() * 1.15);
 
@@ -338,8 +341,8 @@ public class LizzieFrame extends JFrame {
 
         int maxSize = (int) (Math.min(getWidth(), getHeight()) * 0.98);
 
-        Font font = new Font("Open Sans", Font.PLAIN, (int) (maxSize * 0.03));
-        String commandString = "hold x = view controls";
+        Font font = new Font(systemDefaultFontName, Font.PLAIN, (int) (maxSize * 0.03));
+        String commandString = resourceBundle.getString("LizzieFrame.prompt.showControlsHint");
         int strokeRadius = 2;
 
         int showCommandsHeight = (int) (font.getSize() * 1.1);

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -1,0 +1,40 @@
+# Note for localization
+#
+# The localization file set(resource bundle) consist of one base file(this file) and several translated property files.
+# Each localized string is assigned a unique key. All keys referenced in codes should be present in the base file.
+# If a key is present in the translated file matching the current system locale, the value in the translated
+# file will be used. Otherwise the value in the base file will be used instead.
+# Usually strings in the base file are written in English. So that if a string has no translations, it will be
+# displayed in English by default.
+#
+# In Java 8 or before, the encoding of the resource bundle files has no standards.
+# To avoid encoding inconsistencies, it is recommended to use "native2ascii" tool in JDK
+# to encode native translations in raw unicode codes, such as \u0001 \u0002 if the native strings
+# cannot be encoded in ascii. Typically east Asian translations, such as Chinese(both simplified and traditional),
+# Korean or Japanese, need the encoding process.
+#
+# You can directly use the original display texts as the key, but it is recommended to name the key properly.
+
+LizzieFrame.commands.keyAltC=alt-c|copy SGF to clipboard
+LizzieFrame.commands.keyAltV=alt-v|paste SGF from clipboard
+LizzieFrame.commands.keyC=c|toggle coordinates
+LizzieFrame.commands.keyControl=ctrl|undo/redo 10 moves
+LizzieFrame.commands.keyEnd=end|go to end
+LizzieFrame.commands.keyEnter=enter|force Leela Zero move
+LizzieFrame.commands.keyHome=home|go to start
+LizzieFrame.commands.keyI=i|edit game info
+LizzieFrame.commands.keyLeftArrow=left arrow|undo
+LizzieFrame.commands.keyM=m|show/hide move number
+LizzieFrame.commands.keyN=n|start game against Leela Zero
+LizzieFrame.commands.keyO=o|open SGF
+LizzieFrame.commands.keyP=p|pass
+LizzieFrame.commands.keyRightArrow=right arrow|redo
+LizzieFrame.commands.keyS=s|save SGF
+LizzieFrame.commands.keySpace=space|toggle pondering
+LizzieFrame.commands.keyV=v|toggle variation display
+LizzieFrame.commands.mouseWheelScroll=scrollwheel|undo/redo
+LizzieFrame.commands.rightClick=right click|undo
+LizzieFrame.prompt.failedToOpenSgf=Failed to open the SGF file.
+LizzieFrame.prompt.failedToSaveSgf=Failed to save the SGF file.
+LizzieFrame.prompt.sgfExists=The SGF file already exists, do you want to replace it?
+LizzieFrame.prompt.showControlsHint=hold x = view controls

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -1,0 +1,29 @@
+# In Java 8 or before, the encoding of the resource bundle files has no standards.
+# To avoid encoding inconsistencies, it is recommended to use "native2ascii" tool in JDK
+# to encode native translations in raw unicode codes, such as \u0001 \u0002 if the native strings
+# cannot be encoded in ascii. Typically east Asian translations, such as Chinese(both simplified and traditional),
+# Korean or Japanese, need the encoding process.
+
+LizzieFrame.commands.keyAltC=alt-c|\u62f7\u8d1dSGF\u5230\u526a\u8d34\u677f
+LizzieFrame.commands.keyAltV=alt-v|\u4ece\u526a\u8d34\u677f\u7c98\u8d34SGF\u5c40\u9762
+LizzieFrame.commands.keyC=c|\u663e\u793a/\u9690\u85cf\u5750\u6807
+LizzieFrame.commands.keyControl=ctrl|\u5411\u524d/\u5411\u540e10\u6b65
+LizzieFrame.commands.keyEnd=end|\u8df3\u5230\u68cb\u8c31\u672b\u5c3e
+LizzieFrame.commands.keyEnter=enter|\u8ba9Leela Zero\u843d\u5b50
+LizzieFrame.commands.keyHome=home|\u8df3\u8f6c\u5230\u68cb\u8c31\u5f00\u5934
+LizzieFrame.commands.keyI=i|\u7f16\u8f91\u68cb\u5c40\u4fe1\u606f
+LizzieFrame.commands.keyLeftArrow=\u5de6\u65b9\u5411\u952e|\u56de\u4e0a\u4e00\u624b
+LizzieFrame.commands.keyM=m|\u663e\u793a/\u9690\u85cf\u624b\u6570
+LizzieFrame.commands.keyN=n|\u5f00\u59cb\u4e0eLeela Zero\u7684\u5bf9\u5f08
+LizzieFrame.commands.keyO=o|\u6253\u5f00SGF\u6587\u4ef6
+LizzieFrame.commands.keyP=p|\u505c\u4e00\u624b
+LizzieFrame.commands.keyRightArrow=\u53f3\u65b9\u5411\u952e|\u5230\u4e0b\u4e00\u624b
+LizzieFrame.commands.keyS=s|\u4fdd\u5b58SGF
+LizzieFrame.commands.keySpace=\u7a7a\u683c|\u542f\u52a8/\u6682\u505c\u540e\u53f0\u5206\u6790
+LizzieFrame.commands.keyV=v|\u663e\u793a/\u9690\u85cf\u53d8\u5316\u56fe
+LizzieFrame.commands.mouseWheelScroll=\u9f20\u6807\u6eda\u8f6e|\u5728\u68cb\u8c31\u4e2d\u5411\u524d/\u5411\u540e\u79fb\u52a8
+LizzieFrame.commands.rightClick=\u9f20\u6807\u53f3\u952e|\u56de\u4e0a\u4e00\u624b
+LizzieFrame.prompt.failedToOpenSgf=\u4e0d\u80fd\u6253\u5f00SGF\u6587\u4ef6.
+LizzieFrame.prompt.failedToSaveSgf=\u4e0d\u80fd\u4fdd\u5b58SGF\u6587\u4ef6.
+LizzieFrame.prompt.sgfExists=SGF\u6587\u4ef6\u5df2\u7ecf\u5b58\u5728, \u9700\u8981\u66ff\u6362\u5417?
+LizzieFrame.prompt.showControlsHint=\u6309\u4f4fX\u4e0d\u653e\u67e5\u770b\u5feb\u6377\u952e\u63d0\u793a


### PR DESCRIPTION
This PR addresses #79. It changed some codes to use `ResourceBundle` in Java to display localized strings.

Before the change, a piece of code may display a hard-coded string:
```
displayString("Some hard coded string");
```

After the change, the code will use resource bundle to get localized string:
```
displayString(resourceBundle.getString("The.key.of.the.string"));
```
And in the base translation file:
```
The.key.of.the.string=Some hard coded string
```
In localized translation file:
```
The.key.of.the.string=......(Localized translations)
```

I made simplifiled Chinese translations too. But there's no translations of other languages. So Lizzie will display Chinese in a system with locale set to zh_CN, and display English by default in all other systems. If someone could help translation, he should copy the base file (`DisplayStrings.properties`) to a new file with the locale postfix(for example `DisplayStrings_jp.properties` for Japanese) and translate the strings.