### PR TITLE
Property to toggle Leela Zero variation display

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -42,6 +42,8 @@ public class Config {
             }
         }
 
+        showBranch = config.getJSONObject("ui").getBoolean("show-leelaz-variation");
+
         fp.close();
     }
 
@@ -81,6 +83,7 @@ public class Config {
         ui.put("fancy-stones", true);
         ui.put("fancy-board", true);
         ui.put("shadow-size", 100);
+        ui.put("show-leelaz-variation", true);
 
         ui.put("confirm-exit", false);
 


### PR DESCRIPTION
One last flag to make it easy to run Lizzie the way I (and presumably some others) like. `show-leelaz-variation` controls whether Leela Zero's principal variation is displayed. Defaults to true (current behavior).