### PR TITLE
Navigate variation

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -85,6 +85,20 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
             Lizzie.board.nextMove();
     }
 
+    private void nextBranch() {
+        if (Lizzie.frame.isPlayingAgainstLeelaz) {
+            Lizzie.frame.isPlayingAgainstLeelaz = false;
+        }
+        Lizzie.board.nextBranch();
+    }
+
+    private void previousBranch() {
+        if (Lizzie.frame.isPlayingAgainstLeelaz) {
+            Lizzie.frame.isPlayingAgainstLeelaz = false;
+        }
+        Lizzie.board.previousBranch();
+    }
+
     @Override
     public void keyPressed(KeyEvent e) {
 
@@ -105,12 +119,21 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
 
             case VK_RIGHT:
-                redo();
+                nextBranch();
                 break;
 
             case VK_LEFT:
+                previousBranch();
+                break;
+
+            case VK_UP:
                 undo();
                 break;
+
+            case VK_DOWN:
+                redo();
+                break;
+
             case VK_N:
                 // stop the ponder
                 if (Lizzie.leelaz.isPondering())

--- a/src/main/java/wagner/stephanie/lizzie/gui/VariationTree.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/VariationTree.java
@@ -1,6 +1,7 @@
 package wagner.stephanie.lizzie.gui;
 
 import wagner.stephanie.lizzie.Lizzie;
+import wagner.stephanie.lizzie.rules.BoardHistoryList;
 import wagner.stephanie.lizzie.rules.BoardHistoryNode;
 
 import java.awt.*;
@@ -20,38 +21,14 @@ public class VariationTree {
         laneUsageList = new ArrayList<Integer>();
     }
 
-    private int getDepth(BoardHistoryNode node)
-    {
-        int c = 0;
-        while (node.next() != null)
-        {
-            c++;
-            node = node.next();
-        }
-        return c;
-    }
-
-    public BoardHistoryNode findTop(BoardHistoryNode start)
-    {
-        BoardHistoryNode top = start;
-        while (start.previous() != null)
-        {
-            if (start.previous().next() != start)
-            {
-                top = start.previous();
-            }
-            start = start.previous();
-        }
-        return top;
-    }
-
     public void drawTree(Graphics2D g, int posx, int posy, int startLane, int maxposy, BoardHistoryNode startNode, int variationNumber, boolean isMain)
     {
         if (isMain) g.setColor(Color.white);
         else g.setColor(Color.gray.brighter());
 
+
         // Finds depth on leftmost variation of this tree
-        int depth = getDepth(startNode) + 1;
+        int depth = BoardHistoryList.getDepth(startNode) + 1;
         int lane = startLane;
         // Figures out how far out too the right (which lane) we have to go not to collide with other variations
         while (lane < laneUsageList.size() && laneUsageList.get(lane) <= startNode.getData().moveNumber + depth) {
@@ -114,10 +91,10 @@ public class VariationTree {
             cur = cur.previous();
             int curwidth = lane;
             // Draw each variation, uses recursion
-            for (int i = 1; i < cur.allVariants().size(); i++) {
+            for (int i = 1; i < cur.numberOfChildren(); i++) {
                 curwidth++;
                 // Recursion, depth of recursion will normally not be very deep (one recursion level for every variation that has a variation (sort of))
-                drawTree(g, posx, posy, curwidth, maxposy, cur.allVariants().get(i), i,false);
+                drawTree(g, posx, posy, curwidth, maxposy, cur.getVariation(i), i,false);
             }
             posy -= YSPACING;
         }
@@ -145,7 +122,7 @@ public class VariationTree {
         curMove = Lizzie.board.getHistory().getCurrentHistoryNode();
 
         // Is current move a variation? If so, find top of variation
-        BoardHistoryNode top = findTop(curMove);
+        BoardHistoryNode top = BoardHistoryList.findTop(curMove);
         int curposy = middleY - YSPACING*(curMove.getData().moveNumber - top.getData().moveNumber);
         // Go to very top of tree (visible in assigned area)
         BoardHistoryNode node = top;

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
@@ -178,4 +178,19 @@ public class BoardHistoryList {
         // no position matched this position, so it's valid
         return false;
     }
+
+    /*
+     * Static helper methods
+     */
+    static public int getDepth(BoardHistoryNode node)
+    {
+        int c = 0;
+        while (node.next() != null)
+        {
+            c++;
+            node = node.next();
+        }
+        return c;
+    }
+
 }

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
@@ -77,6 +77,20 @@ public class BoardHistoryList {
     }
 
     /**
+     * moves the pointer to the variation number idx, returns the data stored there
+     *
+     * @return the data of next node, null if there is no variaton with index
+     */
+    public BoardData nextVariation(int idx) {
+        if (head.getVariation(idx) == null)
+            return null;
+        else
+            head = head.getVariation(idx);
+
+        return head.getData();
+    }
+
+    /**
      * Does not change the pointer position
      *
      * @return the data stored at the next index. null if not present
@@ -182,6 +196,12 @@ public class BoardHistoryList {
     /*
      * Static helper methods
      */
+
+    /**
+     * Returns the number of moves in a tree (only the left-most (trunk) variation)
+     *
+     * @return number of moves in a tree
+     */
     static public int getDepth(BoardHistoryNode node)
     {
         int c = 0;
@@ -191,6 +211,98 @@ public class BoardHistoryList {
             node = node.next();
         }
         return c;
+    }
+
+    /**
+     * Check if there is a branch that is at least depth deep (at least depth moves)
+     *
+     * @return true if it is deep enough, false otherwise
+     */
+    static public boolean hasDepth(BoardHistoryNode node, int depth) {
+        int c = 0;
+        if (depth <= 0) return true;
+        while (node.next() != null) {
+            if (node.numberOfChildren() > 1) {
+                for (int i = 0; i < node.numberOfChildren(); i++) {
+                    if (hasDepth(node.getVariation(i), depth - c - 1))
+                        return true;
+                }
+                return false;
+            } else {
+                node = node.next();
+                c++;
+                if (c >= depth) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Find top of variation (the first move that is on the main trunk)
+     *
+     * @return top of variaton, if on main trunk, return start move
+     */
+    static public BoardHistoryNode findTop(BoardHistoryNode start)
+    {
+        BoardHistoryNode top = start;
+        while (start.previous() != null)
+        {
+            if (start.previous().next() != start)
+            {
+                top = start.previous();
+            }
+            start = start.previous();
+        }
+        return top;
+    }
+
+    /**
+     * Find first move with variations in tree above node
+     *
+     * @return The child (in the current variation) of the first node with variations
+     */
+    static public BoardHistoryNode findChildOfPreviousWithVariation(BoardHistoryNode node)
+    {
+        while (node.previous() != null)
+        {
+            if (node.previous().numberOfChildren() > 1)
+            {
+                return node;
+            }
+            node = node.previous();
+        }
+        return null;
+    }
+
+    /**
+     * Given a parent node and a child node, find the index of the child node
+     *
+     * @return index of child node, -1 if child node not a child of parent
+     */
+    static public int findIndexOfNode(BoardHistoryNode parentNode, BoardHistoryNode childNode)
+    {
+        if (parentNode.next() == null) return -1;
+        for (int i = 0; i < parentNode.numberOfChildren(); i++)
+        {
+            if (parentNode.getVariation(i) == childNode) return i;
+        }
+        return -1;
+    }
+
+    /**
+     * Check if node is part of the main trunk (rightmost branch)
+     *
+     * @return true if node is part of main trunk, false otherwise
+     */
+    static public boolean isMainTrunk(BoardHistoryNode node)
+    {
+        while (node.previous() != null) {
+            if (node.previous().next() != node) {
+                return false;
+            }
+            node = node.previous();
+        }
+        return true;
     }
 
 }

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryNode.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryNode.java
@@ -107,11 +107,19 @@ public class BoardHistoryNode {
         }
     }
 
-    public ArrayList<BoardHistoryNode> allVariants() {
-        if (nexts.size() == 0) {
+    public int numberOfChildren() {
+        if (nexts == null) {
+            return 0;
+        } else {
+            return nexts.size();
+        }
+    }
+
+    public BoardHistoryNode getVariation(int idx) {
+        if (nexts.size() <= idx) {
             return null;
         } else {
-            return nexts;
+            return nexts.get(idx);
         }
     }
 }


### PR DESCRIPTION
I've added support for navigating between variations using arrow keys. Basically, you move between moves with same move number.

There are two design choices I made that is good to be aware of.
- When moving to the right (variations), you are only allowed to move to variations that start on the same move on the main trunk. No such limitations when you're moving the other way. Possible to allow to move to any variation, but then you have to search the entire tree.
- If a variation is longer than the main branch (trunk), you are still allowed to move back to trunk

Disclaimer: There might be a more elegant way to do this (felt like a long complicated algorithm for something that "simple"), but I haven't spent any time looking for better solutions. Anyway, it works (I hope).

