### PR TITLE
Default properties

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -80,7 +80,7 @@ public class Config {
                 }
             }
         }
-        return true;
+        return modified;
     }
 
     public void toggleShowMoveNumber() {

--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -3,11 +3,11 @@ package wagner.stephanie.lizzie;
 import org.json.*;
 
 import java.io.*;
+import java.util.Iterator;
 
 public class Config {
 
     public boolean showMoveNumber = false;
-    public boolean showVariation = true;
     public boolean showWinrate = true;
     public boolean showVariationGraph = true;
     
@@ -19,11 +19,13 @@ public class Config {
     public JSONObject config;
     
     public Config() throws IOException {
+        JSONObject defaultConfig = createDefaultConfig();
+
         File file = new File("lizzie.properties");
         if (!file.canRead()) {
             System.err.println("Creating config file");
             try {
-                createNewConfig(file);
+                writeConfig(defaultConfig, file);
             } catch (JSONException e) {
                 e.printStackTrace();
                 System.exit(1);
@@ -33,19 +35,52 @@ public class Config {
         FileInputStream fp = new FileInputStream(file);
 
         this.config = null;
+        boolean modified = false;
+        try {
+            this.config = new JSONObject(new JSONTokener(fp));
+            modified = merge_defaults(this.config, defaultConfig);
+        } catch (JSONException e) {
+            this.config = null;
+            e.printStackTrace();
+        }
+        
+        fp.close();
 
-        while (this.config == null) {
-            try {
-                this.config = new JSONObject(new JSONTokener(fp));
-            } catch (JSONException e) {
-                this.config = null;
-                e.printStackTrace();
-            }
+        if (modified) {
+            writeConfig(this.config, file);
         }
 
-        showBranch = config.getJSONObject("ui").getBoolean("show-leelaz-variation");
+        JSONObject uiConfig = config.getJSONObject("ui");
+        showMoveNumber = uiConfig.getBoolean("show-move-number");
+        showBranch = uiConfig.getBoolean("show-leelaz-variation");
+        showWinrate = uiConfig.getBoolean("show-winrate");
+        showVariationGraph = uiConfig.getBoolean("show-variation-graph");
+        showBestMoves = uiConfig.getBoolean("show-best-moves");
+    }
 
-        fp.close();
+    // Modifies config by adding in values from default_config that are missing.
+    // Returns whether it added anything.
+    public boolean merge_defaults(JSONObject config, JSONObject defaults_config) {
+        boolean modified = false;
+        Iterator<String> keys = defaults_config.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            Object new_val = defaults_config.get(key);
+            if (new_val instanceof JSONObject) {
+                if (!config.has(key)) {
+                    config.put(key, new JSONObject());
+                    modified = true;
+                }
+                Object old_val = config.get(key);
+                modified |= merge_defaults((JSONObject) old_val, (JSONObject) new_val);
+            } else {
+                if (!config.has(key)) {
+                    config.put(key, new_val);
+                    modified = true;
+                }
+            }
+        }
+        return true;
     }
 
     public void toggleShowMoveNumber() {
@@ -60,13 +95,12 @@ public class Config {
     public void toggleShowVariationGraph() {
         this.showVariationGraph = !this.showVariationGraph;
     }
-
     public void toggleShowBestMoves() {
         this.showBestMoves = !this.showBestMoves;
     }
 
-    private void createNewConfig(File file) throws IOException, JSONException {
-        config = new JSONObject();
+    private JSONObject createDefaultConfig() {
+        JSONObject config = new JSONObject();
 
         // About engine parameter
         JSONObject leelaz = new JSONObject();
@@ -88,12 +122,19 @@ public class Config {
         ui.put("fancy-stones", true);
         ui.put("fancy-board", true);
         ui.put("shadow-size", 100);
+        ui.put("show-move-number", false);
         ui.put("show-leelaz-variation", true);
+        ui.put("show-winrate", true);
+        ui.put("show-variation-graph", true);
+        ui.put("show-best-moves", true);
         ui.put("win-rate-always-black", false);
         ui.put("confirm-exit", false);
 
         config.put("ui", ui);
+        return config;
+    }
 
+    private void writeConfig(JSONObject config, File file) throws IOException, JSONException {
         file.createNewFile();
 
         FileOutputStream fp = new FileOutputStream(file);


### PR DESCRIPTION
Fixes #108. We create a list of default properties, and if the user's config file is missing any of them (or if they don't have a config file at all), we add the default key-value pairs and save the new config out.

I also added config properties for all the options that can currently be toggled in the UI for completeness, now that it's trivial.