### PR TITLE
Hotkey/property to disable next move display

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -15,6 +15,7 @@ public class Config {
     public boolean showBranch = true;
 
     public boolean showBestMoves = true;
+    public boolean showNextMoves = true;
     
     public JSONObject config;
     
@@ -56,6 +57,7 @@ public class Config {
         showWinrate = uiConfig.getBoolean("show-winrate");
         showVariationGraph = uiConfig.getBoolean("show-variation-graph");
         showBestMoves = uiConfig.getBoolean("show-best-moves");
+        showNextMoves = uiConfig.getBoolean("show-next-moves");
     }
 
     // Modifies config by adding in values from default_config that are missing.
@@ -98,6 +100,9 @@ public class Config {
     public void toggleShowBestMoves() {
         this.showBestMoves = !this.showBestMoves;
     }
+    public void toggleShowNextMoves() {
+        this.showNextMoves = !this.showNextMoves;
+    }
 
     private JSONObject createDefaultConfig() {
         JSONObject config = new JSONObject();
@@ -127,6 +132,7 @@ public class Config {
         ui.put("show-winrate", true);
         ui.put("show-variation-graph", true);
         ui.put("show-best-moves", true);
+        ui.put("show-next-moves", true);
         ui.put("win-rate-always-black", false);
         ui.put("confirm-exit", false);
 

--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -84,7 +84,9 @@ public class BoardRenderer {
         if (!Lizzie.frame.isPlayingAgainstLeelaz && Lizzie.config.showBestMoves)
             drawLeelazSuggestions(g);
 
-        drawNextMoves(g);
+        if (Lizzie.config.showNextMoves) {
+            drawNextMoves(g);
+        }
 
         PluginManager.onDraw(g);
 //        timer.lap("leelaz");

--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -156,6 +156,10 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 Lizzie.config.toggleShowMoveNumber();
                 break;
 
+            case VK_F:
+                Lizzie.config.toggleShowNextMoves();
+                break;
+
             case VK_I:
                 // stop the ponder
                 if (Lizzie.leelaz.isPondering())

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -56,6 +56,7 @@ public class LizzieFrame extends JFrame {
             resourceBundle.getString("LizzieFrame.commands.keyS"),
             resourceBundle.getString("LizzieFrame.commands.keyAltC"),
             resourceBundle.getString("LizzieFrame.commands.keyAltV"),
+            resourceBundle.getString("LizzieFrame.commands.keyF"),
             resourceBundle.getString("LizzieFrame.commands.keyV"),
             resourceBundle.getString("LizzieFrame.commands.keyW"),
             resourceBundle.getString("LizzieFrame.commands.keyG"),

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -22,6 +22,7 @@ LizzieFrame.commands.keyControl=ctrl|undo/redo 10 moves
 LizzieFrame.commands.keyDownArrow=down arrow|redo
 LizzieFrame.commands.keyEnd=end|go to end
 LizzieFrame.commands.keyEnter=enter|force Leela Zero move
+LizzieFrame.commands.keyF=f|toggle next move display
 LizzieFrame.commands.keyG=g|toggle variation graph
 LizzieFrame.commands.keyHome=home|go to start
 LizzieFrame.commands.keyI=i|edit game info

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -10,6 +10,7 @@ LizzieFrame.commands.keyC=c|\u663e\u793a/\u9690\u85cf\u5750\u6807
 LizzieFrame.commands.keyControl=ctrl|\u5411\u524d/\u5411\u540e10\u6b65
 LizzieFrame.commands.keyEnd=end|\u8df3\u5230\u68cb\u8c31\u672b\u5c3e
 LizzieFrame.commands.keyEnter=enter|\u8ba9Leela Zero\u843d\u5b50
+LizzieFrame.commands.keyF=f|toggle next move display
 LizzieFrame.commands.keyHome=home|\u8df3\u8f6c\u5230\u68cb\u8c31\u5f00\u5934
 LizzieFrame.commands.keyI=i|\u7f16\u8f91\u68cb\u5c40\u4fe1\u606f
 LizzieFrame.commands.keyLeftArrow=\u5de6\u65b9\u5411\u952e|\u56de\u4e0a\u4e00\u624b


### PR DESCRIPTION
Fixes #122. `n` was taken so I used `f` for "future" or "forward".