### PR TITLE
Only display visited nodes on winrate graph

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/analysis/Branch.java
+++ b/src/main/java/wagner/stephanie/lizzie/analysis/Branch.java
@@ -22,7 +22,8 @@ public class Branch {
         Zobrist zobrist = board.getData().zobrist == null ? null : board.getData().zobrist.clone();
 
         // Dont care about winrate for branch
-        this.data = new BoardData(stones, lastMove, lastMoveColor, blackToPlay, zobrist, moveNumber, moveNumberList ,0.0);
+        this.data = new BoardData(stones, lastMove, lastMoveColor, blackToPlay,
+                                  zobrist, moveNumber, moveNumberList, 0.0, 0);
 
         for (int i = 0; i < variation.size(); i++) {
             int[] coord = Board.convertNameToCoordinates(variation.get(i));

--- a/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
+++ b/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
@@ -357,23 +357,39 @@ public class Leelaz {
         return isPondering;
     }
 
+    public class WinrateStats {
+        public double maxWinrate;
+        public int totalPlayouts;
+
+        public WinrateStats(double maxWinrate, int totalPlayouts) {
+            this.maxWinrate = maxWinrate;
+            this.totalPlayouts = totalPlayouts;
+        }
+    }
+
     /*
-     * Return the best win rate, returns negative number if no analysis is available
+     * Return the best win rate and total number of playouts.
+     * If no analysis available, win rate is negative and playouts is 0.
      */
-    public double getBestWinrate() {
-        double maxWinrate = -100;
+    public WinrateStats getWinrateStats() {
+        WinrateStats stats = new WinrateStats(-100, 0);
 
         if (bestMoves != null && !bestMoves.isEmpty()) {
             // we should match the Leelaz UCTNode get_eval, which is a weighted average
             final List<MoveData> moves = bestMoves;
 
             // get the total number of playouts in moves
-            int totalPlayouts = moves.stream().reduce(0, (Integer result, MoveData move) -> result + move.playouts, (Integer a, Integer b) -> a + b);
+            stats.totalPlayouts = moves.stream().reduce(0,
+                                                        (Integer result, MoveData move) -> result + move.playouts,
+                                                        (Integer a, Integer b) -> a + b);
 
             // set maxWinrate to the weighted average winrate of moves
-            maxWinrate = moves.stream().reduce(0d, (Double result, MoveData move) -> result + move.winrate * move.playouts / totalPlayouts, (Double a, Double b) -> a + b);
+            stats.maxWinrate = moves.stream().reduce(0d,
+                                                     (Double result, MoveData move) ->
+                                                         result + move.winrate * move.playouts / stats.totalPlayouts,
+                                                     (Double a, Double b) -> a + b);
         }
 
-        return maxWinrate;
+        return stats;
     }
 }

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -14,6 +14,7 @@ import java.awt.RenderingHints;
 import com.jhlabs.image.GaussianFilter;
 import wagner.stephanie.lizzie.Lizzie;
 import wagner.stephanie.lizzie.analysis.GameInfo;
+import wagner.stephanie.lizzie.analysis.Leelaz;
 import wagner.stephanie.lizzie.rules.Board;
 import wagner.stephanie.lizzie.rules.SGFParser;
 
@@ -455,7 +456,8 @@ public class LizzieFrame extends JFrame {
         else
             lastWR = Lizzie.board.getHistory().getPrevious().winrate;
 
-        double curWR = Lizzie.leelaz.getBestWinrate();
+        Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
+        double curWR = stats.maxWinrate;
         if (isPlayingAgainstLeelaz && playerIsBlack == !Lizzie.board.getHistory().getData().blackToPlay)
             curWR = -100;
 

--- a/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
@@ -58,47 +58,54 @@ public class WinrateGraph {
         // Plot
         width = (int)(width*0.95); // Leave some space after last move
         double lastWr = 50;
+        boolean lastNodeOk = false;
         int movenum = numMoves;
         g.setColor(Color.green);
         g.setStroke(new BasicStroke(3));
-        boolean isFirst = true;
 
         while (node.previous() != null)
         {
             double wr = node.getData().winrate;
+            int playouts = node.getData().playouts;
             if (node == curMove)
             {
                 Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
                 double bwr = stats.maxWinrate;
-                if (bwr >= 0) {
+                if (bwr >= 0 && stats.totalPlayouts > playouts) {
                     wr = bwr;
+                    playouts = stats.totalPlayouts;
                 }
             }
-            if (wr < 0)
-            {
-                wr = 100 - lastWr;
-            }
-            else if (!node.getData().blackToPlay)
-            {
-                wr = 100 - wr;
-            }
-            if (Lizzie.frame.isPlayingAgainstLeelaz && Lizzie.frame.playerIsBlack == !node.getData().blackToPlay) {
-                wr = lastWr;
-            }
+            System.out.printf("movenum %d playouts %d winrate %f\n", movenum, playouts, wr);
+            if (playouts > 0) {
+               if (wr < 0)
+               {
+                  wr = 100 - lastWr;
+               }
+               else if (!node.getData().blackToPlay)
+               {
+                  wr = 100 - wr;
+               }
+               if (Lizzie.frame.isPlayingAgainstLeelaz && Lizzie.frame.playerIsBlack == !node.getData().blackToPlay) {
+                  wr = lastWr;
+               }
 
-            if (!isFirst)
-                g.drawLine(posx + ((movenum + 1)*width/numMoves),
-                           posy + height - (int)(lastWr*height/100),
-                           posx + (movenum*width/numMoves),
-                           posy + height - (int)(wr*height/100));
-            isFirst = false;
-            if (node == curMove)
-                g.fillOval(posx + (movenum*width/numMoves) - DOT_RADIUS,
-                           posy + height - (int)(wr*height/100) - DOT_RADIUS,
-                           DOT_RADIUS*2,
-                           DOT_RADIUS*2);
+               if (lastNodeOk)
+                  g.drawLine(posx + ((movenum + 1)*width/numMoves),
+                             posy + height - (int)(lastWr*height/100),
+                             posx + (movenum*width/numMoves),
+                             posy + height - (int)(wr*height/100));
+               if (node == curMove)
+                  g.fillOval(posx + (movenum*width/numMoves) - DOT_RADIUS,
+                             posy + height - (int)(wr*height/100) - DOT_RADIUS,
+                             DOT_RADIUS*2,
+                             DOT_RADIUS*2);
+               lastWr = wr;
+               lastNodeOk = true;
+            } else {
+               lastNodeOk = false;
+            }
             node = node.previous();
-            lastWr = wr;
             movenum--;
         }
 

--- a/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
@@ -76,7 +76,6 @@ public class WinrateGraph {
                     playouts = stats.totalPlayouts;
                 }
             }
-            System.out.printf("movenum %d playouts %d winrate %f\n", movenum, playouts, wr);
             if (playouts > 0) {
                if (wr < 0)
                {

--- a/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
@@ -1,6 +1,7 @@
 package wagner.stephanie.lizzie.gui;
 
 import wagner.stephanie.lizzie.Lizzie;
+import wagner.stephanie.lizzie.analysis.Leelaz;
 import wagner.stephanie.lizzie.rules.BoardHistoryNode;
 
 import java.awt.*;
@@ -67,7 +68,8 @@ public class WinrateGraph {
             double wr = node.getData().winrate;
             if (node == curMove)
             {
-                double bwr = Lizzie.leelaz.getBestWinrate();
+                Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
+                double bwr = stats.maxWinrate;
                 if (bwr >= 0) {
                     wr = bwr;
                 }

--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -366,9 +366,9 @@ public class Board {
         synchronized (this) {
             // Update win rate statistics
             Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
-            double wr = stats.maxWinrate;
-            if (wr >= 0) {
-                history.getData().winrate = wr;
+            if (stats.totalPlayouts >= history.getData().playouts) {
+                history.getData().winrate = stats.maxWinrate;
+                history.getData().playouts = stats.totalPlayouts;
             }
             if (history.next() != null) {
                 // update leelaz board position, before updating to next node
@@ -614,9 +614,9 @@ public class Board {
         synchronized (this) {
             // Update win rate statistics
             Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
-            double wr = stats.maxWinrate;
-            if (wr >= 0) {
-                history.getData().winrate = wr;
+            if (stats.totalPlayouts >= history.getData().playouts) {
+                history.getData().winrate = stats.maxWinrate;
+                history.getData().playouts = stats.totalPlayouts;
             }
             if (history.previous() != null) {
                 Lizzie.leelaz.undo();

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardData.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardData.java
@@ -15,8 +15,9 @@ public class BoardData {
     public boolean verify;
 
     public double winrate;
+    public int playouts;
 
-    public BoardData(Stone[] stones, int[] lastMove, Stone lastMoveColor, boolean blackToPlay, Zobrist zobrist, int moveNumber, int[] moveNumberList, double winrate) {
+    public BoardData(Stone[] stones, int[] lastMove, Stone lastMoveColor, boolean blackToPlay, Zobrist zobrist, int moveNumber, int[] moveNumberList, double winrate, int playouts) {
         this.moveNumber = moveNumber;
         this.lastMove = lastMove;
         this.moveNumberList = moveNumberList;
@@ -28,5 +29,6 @@ public class BoardData {
         this.verify = false;
 
         this.winrate = winrate;
+        this.playouts = playouts;
     }
 }


### PR DESCRIPTION
Fixes #104. `BoardData` now includes the number of Leela Zero playouts for each node, and node stats are updated only when visited more than before. The winrate graph draws lines only where nodes have been visited. This means:

- You don't see long flat lines on the win graph where there is missing data (just loaded an SGF file, or quickly arrowed through part of it)
 - Quickly arrowing through nodes doesn't reset their winrate, which used to cause more long flat lines.