### PR TITLE
Don't display nonexistent info in winrate bar

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -16,6 +16,7 @@ import wagner.stephanie.lizzie.Lizzie;
 import wagner.stephanie.lizzie.analysis.GameInfo;
 import wagner.stephanie.lizzie.analysis.Leelaz;
 import wagner.stephanie.lizzie.rules.Board;
+import wagner.stephanie.lizzie.rules.BoardData;
 import wagner.stephanie.lizzie.rules.SGFParser;
 
 import javax.swing.*;
@@ -450,19 +451,22 @@ public class LizzieFrame extends JFrame {
         if (width < 0 || height < 0)
             return; // we don't have enough space
 
-        double lastWR;
-        if (Lizzie.board.getData().moveNumber == 0)
-            lastWR = 50;
-        else
-            lastWR = Lizzie.board.getHistory().getPrevious().winrate;
+        double lastWR = 50;     // winrate the previous move
+        boolean validLastWinrate = false; // whether it was actually calculated
+        BoardData lastNode = Lizzie.board.getHistory().getPrevious();
+        if (lastNode != null && lastNode.playouts > 0) {
+            lastWR = lastNode.winrate;
+            validLastWinrate = true;
+        }
 
         Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
-        double curWR = stats.maxWinrate;
+        double curWR = stats.maxWinrate; // winrate on this move
+        boolean validWinrate = (stats.totalPlayouts > 0); // and whether it was actually calculated
         if (isPlayingAgainstLeelaz && playerIsBlack == !Lizzie.board.getHistory().getData().blackToPlay)
-            curWR = -100;
+            validWinrate = false;
 
-        if (curWR < 0) {
-            curWR = 100 - lastWR;
+        if (!validWinrate) {
+            curWR = 100 - lastWR; // display last move's winrate for now (with color difference)
         }
         double whiteWR, blackWR;
         if (Lizzie.board.getData().blackToPlay) {
@@ -480,9 +484,12 @@ public class LizzieFrame extends JFrame {
         // border. does not include bottom edge
         int strokeRadius = 3;
         g.setStroke(new BasicStroke(2 * strokeRadius));
-        g.drawLine(posX + strokeRadius, posY + strokeRadius, posX - strokeRadius + width, posY + strokeRadius);
-        g.drawLine(posX + strokeRadius, posY + 3 * strokeRadius, posX + strokeRadius, posY - strokeRadius + height);
-        g.drawLine(posX - strokeRadius + width, posY + 3 * strokeRadius, posX - strokeRadius + width, posY - strokeRadius + height);
+        g.drawLine(posX + strokeRadius, posY + strokeRadius,
+                   posX - strokeRadius + width, posY + strokeRadius);
+        g.drawLine(posX + strokeRadius, posY + 3 * strokeRadius,
+                   posX + strokeRadius, posY - strokeRadius + height);
+        g.drawLine(posX - strokeRadius + width, posY + 3 * strokeRadius,
+                   posX - strokeRadius + width, posY - strokeRadius + height);
 
         // resize the box now so it's inside the border
         posX += 2 * strokeRadius;
@@ -498,43 +505,53 @@ public class LizzieFrame extends JFrame {
         g.setFont(font);
 
         // Last move
-        if (lastWR < 0)
-            // In case leelaz didnt have time to calculate
-            g.drawString(resourceBundle.getString("LizzieFrame.display.lastMove") + ": ?%", posX + 2 * strokeRadius, posY + height - 2 * strokeRadius);
-        else
-            g.drawString(resourceBundle.getString("LizzieFrame.display.lastMove") + String.format(": %.1f%%", 100 - lastWR - curWR), posX + 2 * strokeRadius,
-                    posY + height - 2 * strokeRadius);// - font.getSize());
+        if (validLastWinrate && validWinrate)
+            g.drawString(resourceBundle.getString("LizzieFrame.display.lastMove") +
+                         String.format(": %.1f%%", 100 - lastWR - curWR),
+                         posX + 2 * strokeRadius,
+                         posY + height - 2 * strokeRadius); // - font.getSize());
+        else {
+            // I think it's more elegant to just not display anything when we don't have
+            // valid data --dfannius
+            // g.drawString(resourceBundle.getString("LizzieFrame.display.lastMove") + ": ?%",
+            //              posX + 2 * strokeRadius, posY + height - 2 * strokeRadius);
+        }
 
+        if (validWinrate || validLastWinrate) {
+            int maxBarwidth = (int) (width);
+            int barWidthB = (int) (blackWR * maxBarwidth / 100);
+            int barWidthW = (int) (whiteWR * maxBarwidth / 100);
+            int barPosY = posY + height / 3;
+            int barPosxB = (int) (posX);
+            int barPosxW = barPosxB + barWidthB;
+            int barHeight = height / 3;
 
-        int maxBarwidth = (int) (width);
-        int barWidthB = (int) (blackWR * maxBarwidth / 100);
-        int barWidthW = (int) (whiteWR * maxBarwidth / 100);
-        int barPosY = posY + height / 3;
-        int barPosxB = (int) (posX);
-        int barPosxW = barPosxB + barWidthB;
-        int barHeight = height / 3;
+            // Draw winrate bars
+            g.fillRect(barPosxW, barPosY, barWidthW, barHeight);
+            g.setColor(Color.BLACK);
+            g.fillRect(barPosxB, barPosY, barWidthB, barHeight);
 
-        // Draw winrate bars
-        g.fillRect(barPosxW, barPosY, barWidthW, barHeight);
-        g.setColor(Color.BLACK);
-        g.fillRect(barPosxB, barPosY, barWidthB, barHeight);
+            // Show percentage above bars
+            g.setColor(Color.WHITE);
+            g.drawString(String.format("%.1f%%", blackWR),
+                         barPosxB + 2 * strokeRadius,
+                         posY + barHeight - 2 * strokeRadius);
+            String winString = String.format("%.1f%%", whiteWR);
+            int sw = g.getFontMetrics().stringWidth(winString);
+            g.drawString(winString,
+                         barPosxB + maxBarwidth - sw - 2 * strokeRadius,
+                         posY + barHeight - 2 * strokeRadius);
 
-        // Show percentage above bars
-        g.setColor(Color.WHITE);
-        g.drawString(String.format("%.1f%%", blackWR), barPosxB + 2 * strokeRadius, posY + barHeight - 2 * strokeRadius);
-        String winString = String.format("%.1f%%", whiteWR);
-        int sw = g.getFontMetrics().stringWidth(winString);
-        g.drawString(winString, barPosxB + maxBarwidth - sw - 2 * strokeRadius, posY + barHeight - 2 * strokeRadius);
+            g.setColor(Color.GRAY);
+            Stroke oldstroke = g.getStroke();
+            Stroke dashed = new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0,
+                                            new float[]{4}, 0);
+            g.setStroke(dashed);
 
-        g.setColor(Color.GRAY);
-        Stroke oldstroke = g.getStroke();
-        Stroke dashed = new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0,
-                new float[]{4}, 0);
-        g.setStroke(dashed);
-
-        int middleX = barPosxB + (int) (maxBarwidth / 2);
-        g.drawLine(middleX, barPosY, middleX, barPosY + barHeight);
-        g.setStroke(oldstroke);
+            int middleX = barPosxB + (int) (maxBarwidth / 2);
+            g.drawLine(middleX, barPosY, middleX, barPosY + barHeight);
+            g.setStroke(oldstroke);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #134.

When there's nothing useful to display for the winrate bar, don't display anything.