### PR TITLE
Hotkey to hide variations etc. temporally

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -10,6 +10,7 @@ public class Config {
     public boolean showMoveNumber = false;
     public boolean showWinrate = true;
     public boolean showVariationGraph = true;
+    public boolean showRawBoard = false;
     
     // For plug-ins
     public boolean showBranch = true;

--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -79,13 +79,15 @@ public class BoardRenderer {
         renderImages(g);
 //        timer.lap("rendering images");
 
-        drawMoveNumbers(g);
+        if (!Lizzie.config.showRawBoard) {
+            drawMoveNumbers(g);
 //        timer.lap("movenumbers");
-        if (!Lizzie.frame.isPlayingAgainstLeelaz && Lizzie.config.showBestMoves)
-            drawLeelazSuggestions(g);
+            if (!Lizzie.frame.isPlayingAgainstLeelaz && Lizzie.config.showBestMoves)
+                drawLeelazSuggestions(g);
 
-        if (Lizzie.config.showNextMoves) {
-            drawNextMoves(g);
+            if (Lizzie.config.showNextMoves) {
+                drawNextMoves(g);
+            }
         }
 
         PluginManager.onDraw(g);
@@ -221,7 +223,7 @@ public class BoardRenderer {
         bestMoves = Lizzie.leelaz.getBestMoves();
         branch = null;
 
-        if (!Lizzie.config.showBranch) {
+        if (Lizzie.config.showRawBoard || !Lizzie.config.showBranch) {
             return;
         }
 

--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -257,6 +257,11 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 deleteMove();
                 break;
 
+            case VK_Z:
+                Lizzie.config.showRawBoard = true;
+                Lizzie.frame.repaint();
+                break;
+
             default:
         }
         Lizzie.frame.repaint();
@@ -280,6 +285,11 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 if (wasPonderingWhenControlsShown)
                     Lizzie.leelaz.togglePonder();
                 Lizzie.frame.showControls = false;
+                Lizzie.frame.repaint();
+                break;
+
+            case VK_Z:
+                Lizzie.config.showRawBoard = false;
                 Lizzie.frame.repaint();
                 break;
 


### PR DESCRIPTION
When the board is too complicated with many best moves, I want to hide
variations etc. temporally.  This hotkey (z) works while it is held
down like "x" key.  So I selected "z", the next key in the keyboard.  I
am not sure which key is suitable, though.
