### PR TITLE
Hotkey to go to the top position of the current branch

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -73,6 +73,17 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
             Lizzie.board.previousMove();
     }
 
+    private void undoToChildOfPreviousWithVariation() {
+        // Undo until the position just after the junction position.
+        // If we are already on such a position, we go to
+        // the junction position for convenience.
+        // Use cases:
+        // [Delete branch] Call this function and then deleteMove.
+        // [Go to junction] Call this function twice.
+        if (!Lizzie.board.undoToChildOfPreviousWithVariation())
+            Lizzie.board.previousMove();
+    }
+
     private void redo() {
         if (Lizzie.frame.isPlayingAgainstLeelaz) {
             Lizzie.frame.isPlayingAgainstLeelaz = false;
@@ -145,7 +156,11 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
 
             case VK_UP:
-                undo();
+                if (e.isShiftDown()) {
+                    undoToChildOfPreviousWithVariation();
+                } else {
+                    undo();
+                }
                 break;
 
             case VK_DOWN:

--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -659,4 +659,13 @@ public class Board {
             return false;
         }
     }
+
+    public boolean undoToChildOfPreviousWithVariation() {
+        BoardHistoryNode start = history.getCurrentHistoryNode();
+        BoardHistoryNode goal = history.findChildOfPreviousWithVariation(start);
+        if (start == goal)
+            return false;
+        while ((history.getCurrentHistoryNode() != goal) && previousMove()) ;
+        return true;
+    }
 }


### PR DESCRIPTION
Thanks to the recent Del key feature, I can easily try various moves
with temporal branches.  To make it easier, I added a new hotkey
(shift + up arrow) to go back quickly to the top of the current
branch.  It stops at the child position of the junction position so
that I can delete the current branch conveniently with this key and
Del key.  When I really want to go to the junction position, I simply
hit this key twice.
