### PR TITLE
Hotkey to play the displayed variation

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -48,6 +48,7 @@ public class BoardRenderer {
     private BufferedImage branchStonesShadowImage = null;
 
     public ITheme theme;
+    public List<String> variation;
 
 
     public BoardRenderer() {
@@ -220,6 +221,7 @@ public class BoardRenderer {
         // calculate best moves and branch
         bestMoves = Lizzie.leelaz.getBestMoves();
         branch = null;
+        variation = null;
 
         if (!Lizzie.config.showBranch) {
             return;
@@ -234,7 +236,8 @@ public class BoardRenderer {
                 int[] coord = Board.convertNameToCoordinates(move.coordinate);
 
                 if (coord[0] == Lizzie.frame.mouseHoverCoordinate[0] && coord[1] == Lizzie.frame.mouseHoverCoordinate[1]) {
-                    branch = new Branch(Lizzie.board, move.variation);
+                    variation = move.variation;
+                    branch = new Branch(Lizzie.board, variation);
                     break;
                 }
             }

--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -109,6 +109,10 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
 
     private void deleteMove() { Lizzie.board.deleteMove(); }
 
+    private void playCurrentVariation() {
+        Lizzie.frame.playCurrentVariation();
+    }
+
     @Override
     public void keyPressed(KeyEvent e) {
 
@@ -168,6 +172,10 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
 
             case VK_P:
                 Lizzie.board.pass();
+                break;
+
+            case VK_COMMA:
+                playCurrentVariation();
                 break;
 
             case VK_M:

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -34,6 +34,7 @@ import java.awt.image.BufferStrategy;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.util.Arrays;
+import java.util.List;
 import java.util.ResourceBundle;
 
 /**
@@ -573,6 +574,18 @@ public class LizzieFrame extends JFrame {
         if (boardCoordinates != null) {
             if (!isPlayingAgainstLeelaz || (playerIsBlack == Lizzie.board.getData().blackToPlay))
                 Lizzie.board.place(boardCoordinates[0], boardCoordinates[1]);
+        }
+        repaint();
+    }
+
+    public void playCurrentVariation() {
+        List<String> variation = boardRenderer.variation;
+        if (variation != null) {
+            for (int i = 0; i < variation.size(); i++) {
+                int[] boardCoordinates = Board.convertNameToCoordinates(variation.get(i));
+                if (boardCoordinates != null)
+                    Lizzie.board.place(boardCoordinates[0], boardCoordinates[1]);
+            }
         }
         repaint();
     }


### PR DESCRIPTION
I often want to watch continuations of variations suggested by leelaz
because I cannot understand the reason why their winrates are so
high/low.  I added a hotkey to do it quickly on my slow machine
without GPU.  This hotkey (,) puts stones as the currently displayed
variation, and I can conveniently watch leelaz's prediction further.
I am not sure which key is suitable for this feature.
