### PR TITLE
Fix slow convergence of winrate in small playouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ any `leelaz_opencl_tuning` file you have into the directory.
 First, you will need to have a special version of Leela Zero that
 continually outputs pondering information. You can get this from one
 of the Lizzie releases or build it yourself; just substitute
-`leelaz-src/UCTSearch.cpp` for the `UCTSearch.cpp` file found in the
+`leelaz-src/UCTSearch.cpp` and `leelaz-src/UCTSearch.h` for the
+`UCTSearch.cpp` and `UCTSearch.h` files found in the
 Leela Zero sources. Then copy the resulting `leelaz` to the root of
 the Lizzie directory tree.
 

--- a/leelaz-src/UCTSearch.cpp
+++ b/leelaz-src/UCTSearch.cpp
@@ -618,6 +618,11 @@ int UCTSearch::think(int color, passflag_t passflag) {
 }
 
 void UCTSearch::ponder() {
+    while(ponder_helper()) {};                                      // lizzie
+}
+
+bool UCTSearch::ponder_helper() {                                   // lizzie
+    bool stopped_for_lizzie = false;                                // lizzie
     update_root();
 
     m_run = true;
@@ -641,22 +646,26 @@ void UCTSearch::ponder() {
         Time elapsed;                                               // lizzie
         int elapsed_centis = Time::timediff_centis(start, elapsed); // lizzie
         if (elapsed_centis - last_update > 10) { // lizzie: output ponder data 10 times per second
-            last_update = elapsed_centis;                           // lizzie
-           
-            myprintf("~begin\n");                                   // lizzie
-            dump_stats(m_rootstate, *m_root);                       // lizzie
-            myprintf("~end\n");                                     // lizzie
+            stopped_for_lizzie = keeprunning;                       // lizzie
+            keeprunning = false;                                    // lizzie
         }                                                           // lizzie
     } while(!Utils::input_pending() && keeprunning);
 
     // stop the search
     m_run = false;
     tg.wait_all();
+    if (stopped_for_lizzie) {                                 // lizzie
+      // Be sure to call tg.wait_all before dump_stats.       // lizzie
+      myprintf("~begin\n");                                   // lizzie
+      dump_stats(m_rootstate, *m_root);                       // lizzie
+      myprintf("~end\n");                                     // lizzie
+    }                                                         // lizzie
     // display search info
     myprintf("\n");
     dump_stats(m_rootstate, *m_root);
 
     myprintf("\n%d visits, %d nodes\n\n", m_root->get_visits(), m_nodes.load());
+    return stopped_for_lizzie;                                // lizzie
 }
 
 void UCTSearch::set_playout_limit(int playouts) {

--- a/leelaz-src/UCTSearch.h
+++ b/leelaz-src/UCTSearch.h
@@ -1,0 +1,128 @@
+/*
+    This file is part of Leela Zero.
+    Copyright (C) 2017 Gian-Carlo Pascutto
+
+    Leela Zero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leela Zero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef UCTSEARCH_H_INCLUDED
+#define UCTSEARCH_H_INCLUDED
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "FastBoard.h"
+#include "FastState.h"
+#include "GameState.h"
+#include "UCTNode.h"
+
+
+class SearchResult {
+public:
+    SearchResult() = default;
+    bool valid() const { return m_valid;  }
+    float eval() const { return m_eval;  }
+    static SearchResult from_eval(float eval) {
+        return SearchResult(eval);
+    }
+    static SearchResult from_score(float board_score) {
+        if (board_score > 0.0f) {
+            return SearchResult(1.0f);
+        } else if (board_score < 0.0f) {
+            return SearchResult(0.0f);
+        } else {
+            return SearchResult(0.5f);
+        }
+    }
+private:
+    explicit SearchResult(float eval)
+        : m_valid(true), m_eval(eval) {}
+    bool m_valid{false};
+    float m_eval{0.0f};
+};
+
+namespace TimeManagement {
+    enum enabled_t {
+        AUTO = -1, OFF = 0, ON = 1
+    };
+};
+
+class UCTSearch {
+public:
+    /*
+        Depending on rule set and state of the game, we might
+        prefer to pass, or we might prefer not to pass unless
+        it's the last resort. Same for resigning.
+    */
+    using passflag_t = int;
+    static constexpr passflag_t NORMAL   = 0;
+    static constexpr passflag_t NOPASS   = 1 << 0;
+    static constexpr passflag_t NORESIGN = 1 << 1;
+
+    /*
+        Maximum size of the tree in memory. Nodes are about
+        48 bytes, so limit to ~1.2G on 32-bits and about 5.5G
+        on 64-bits.
+    */
+    static constexpr auto MAX_TREE_SIZE =
+        (sizeof(void*) == 4 ? 25'000'000 : 100'000'000);
+
+    UCTSearch(GameState& g);
+    int think(int color, passflag_t passflag = NORMAL);
+    void set_playout_limit(int playouts);
+    void set_visit_limit(int visits);
+    void ponder();
+    bool is_running() const;
+    void increment_playouts();
+    SearchResult play_simulation(GameState& currstate, UCTNode* const node);
+
+private:
+    bool ponder_helper();                                           // lizzie
+    void dump_stats(FastState& state, UCTNode& parent);
+    void tree_stats(const UCTNode& node);
+    std::string get_pv(FastState& state, UCTNode& parent);
+    void dump_analysis(int playouts);
+    bool should_resign(passflag_t passflag, float bestscore);
+    bool have_alternate_moves(int elapsed_centis, int time_for_move);
+    int est_playouts_left(int elapsed_centis, int time_for_move) const;
+    size_t prune_noncontenders(int elapsed_centis = 0, int time_for_move = 0);
+    bool stop_thinking(int elapsed_centis = 0, int time_for_move = 0) const;
+    int get_best_move(passflag_t passflag);
+    void update_root();
+    bool advance_to_new_rootstate();
+
+    GameState & m_rootstate;
+    std::unique_ptr<GameState> m_last_rootstate;
+    std::unique_ptr<UCTNode> m_root;
+    std::atomic<int> m_nodes{0};
+    std::atomic<int> m_playouts{0};
+    std::atomic<bool> m_run{false};
+    int m_maxplayouts;
+    int m_maxvisits;
+};
+
+class UCTWorker {
+public:
+    UCTWorker(GameState & state, UCTSearch * search, UCTNode * root)
+      : m_rootstate(state), m_search(search), m_root(root) {}
+    void operator()();
+private:
+    GameState & m_rootstate;
+    UCTSearch * m_search;
+    UCTNode * m_root;
+};
+
+#endif


### PR DESCRIPTION
This commit fixes slow convergence of winrate, though I do not
understand the reason :)

Without this commit, the dump_stats() between "~begin" and "~end"
tells too pessimistic values (e.g. 14%) when playouts are small (e.g. 1
or 2).  They cause slow convergence of winrate, that is serious for me
since my machine has no GPU.

I copied leelaz-src/UCTSearch.h in 8b0d598 from
https://github.com/featurecat/leela-zero
and added the line "bool ponder_helper();".
