### PR TITLE
Fix Ctrl key problem when the window focus is moved

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -8,8 +8,6 @@ import static java.awt.event.KeyEvent.*;
 import wagner.stephanie.lizzie.plugin.PluginManager;
 
 public class Input implements MouseListener, KeyListener, MouseWheelListener, MouseMotionListener {
-    private boolean controlIsPressed = false;
-
     @Override
     public void mouseClicked(MouseEvent e) {
 
@@ -62,12 +60,13 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
     }
 
     private void undo() {
+        undo(1);
+    }
+
+    private void undo(int movesToAdvance) {
         if (Lizzie.frame.isPlayingAgainstLeelaz) {
             Lizzie.frame.isPlayingAgainstLeelaz = false;
         }
-        int movesToAdvance = 1;
-        if (controlIsPressed)
-            movesToAdvance = 10;
 
         for (int i = 0; i < movesToAdvance; i++)
             Lizzie.board.previousMove();
@@ -85,12 +84,13 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
     }
 
     private void redo() {
+        redo(1);
+    }
+
+    private void redo(int movesToAdvance) {
         if (Lizzie.frame.isPlayingAgainstLeelaz) {
             Lizzie.frame.isPlayingAgainstLeelaz = false;
         }
-        int movesToAdvance = 1;
-        if (controlIsPressed)
-            movesToAdvance = 10;
 
         for (int i = 0; i < movesToAdvance; i++)
             Lizzie.board.nextMove();
@@ -124,25 +124,17 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
         Lizzie.frame.playCurrentVariation();
     }
 
+    private boolean controlIsPressed(KeyEvent e) {
+        boolean mac = System.getProperty("os.name", "").toUpperCase().startsWith("MAC");
+        return e.isControlDown() || (mac && e.isMetaDown());
+    }
+
     @Override
     public void keyPressed(KeyEvent e) {
 
         PluginManager.onKeyPressed(e);
 
-        int movesToAdvance = 1; // number of moves to advance if control is held down
-
         switch (e.getKeyCode()) {
-            case VK_CONTROL:
-
-                controlIsPressed = true;
-                break;
-
-            case VK_META:
-                if (System.getProperty("os.name", "").toUpperCase().startsWith("MAC")) {
-                    controlIsPressed = true;
-                }
-                break;
-
             case VK_RIGHT:
                 if (e.isShiftDown()) {
                     moveBranchDown();
@@ -162,18 +154,23 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
             case VK_UP:
                 if (e.isShiftDown()) {
                     undoToChildOfPreviousWithVariation();
+                } else if (controlIsPressed(e)) {
+                    undo(10);
                 } else {
                     undo();
                 }
                 break;
                 
             case VK_PAGE_DOWN:
-                for (int i = 0; i < 10; i++)
-                    redo();
+                redo(10);
                 break;
 
             case VK_DOWN:
-                redo();
+                if (controlIsPressed(e)) {
+                    redo(10);
+                } else {
+                    redo();
+                }
                 break;
 
             case VK_N:
@@ -207,8 +204,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
                 
             case VK_PAGE_UP:
-                for (int i = 0; i < 10; i++)
-                    undo();
+                undo(10);
                 break;
 
             case VK_I:
@@ -231,7 +227,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
 
             case VK_V:
-                if (controlIsPressed) {
+                if (controlIsPressed(e)) {
                     Lizzie.frame.pasteSgf();
                 } else {
                     Lizzie.config.toggleShowBranch();
@@ -269,7 +265,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
 
             case VK_C:
-                if (controlIsPressed) {
+                if (controlIsPressed(e)) {
                     Lizzie.frame.copySgf();
                 } else {
                     Lizzie.frame.toggleCoordinates();
@@ -312,15 +308,6 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
     public void keyReleased(KeyEvent e) {
         PluginManager.onKeyReleased(e);
         switch (e.getKeyCode()) {
-            case VK_CONTROL:
-                controlIsPressed = false;
-                break;
-
-            case VK_META:
-                if (System.getProperty("os.name", "").toUpperCase().startsWith("MAC")) {
-                    controlIsPressed = false;
-                }
-
             case VK_X:
                 if (wasPonderingWhenControlsShown)
                     Lizzie.leelaz.togglePonder();


### PR DESCRIPTION
I use Control key to move the window focus, e.g. Ctrl+Tab to raise
another window, Ctrl+F3 to go to the workspace 3, etc.  When I use
these shortcuts and return to Lizzie later, it is still in "Ctrl"
state and Up/Down arrow keys cause 10 moves without this commit.

Steps to reproduce the problem:
(1) Start Lizzie and put some stones.
(2) Holding Ctrl key in Lizzie window, move the focus to another window.
(3) Release Ctrl key.
(4) Click Lizzie window to move the focus back.
(5) Hit Up arrow key.
I expect a single undo in (5). But I get 10 undos instead.
