### PR TITLE
Handicap stones graph instead of winrate graph

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -11,6 +11,7 @@ public class Config {
     public boolean showWinrate = true;
     public boolean showVariationGraph = true;
     public boolean showRawBoard = false;
+    public boolean handicapInsteadOfWinrate = false;
     
     // For plug-ins
     public boolean showBranch = true;
@@ -73,6 +74,7 @@ public class Config {
         showVariationGraph = uiConfig.getBoolean("show-variation-graph");
         showBestMoves = uiConfig.getBoolean("show-best-moves");
         showNextMoves = uiConfig.getBoolean("show-next-moves");
+        handicapInsteadOfWinrate = uiConfig.getBoolean("handicap-instead-of-winrate");
     }
 
     // Modifies config by adding in values from default_config that are missing.
@@ -118,6 +120,11 @@ public class Config {
     public void toggleShowNextMoves() {
         this.showNextMoves = !this.showNextMoves;
     }
+    public void toggleHandicapInsteadOfWinrate() {
+        this.handicapInsteadOfWinrate = !this.handicapInsteadOfWinrate;
+    }
+
+
 
     private JSONObject createDefaultConfig() {
         JSONObject config = new JSONObject();

--- a/src/main/java/wagner/stephanie/lizzie/Lizzie.java
+++ b/src/main/java/wagner/stephanie/lizzie/Lizzie.java
@@ -38,7 +38,7 @@ public class Lizzie {
         new Thread( () -> {
             try {
                 leelaz = new Leelaz();
-                if( config.config.getJSONObject("ui").getBoolean("handicap-instead-of-winrate") ) {
+                if(config.handicapInsteadOfWinrate) {
                 	leelaz.estimatePassWinrate();
                 }
                 leelaz.togglePonder();

--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -462,7 +462,7 @@ public class BoardRenderer {
                             g.setColor(Color.WHITE);
                         
                         String text;
-                        if( uiConfig.getBoolean("handicap-instead-of-winrate") ) {
+                        if (Lizzie.config.handicapInsteadOfWinrate) {
                             text=String.format("%.2f", Lizzie.leelaz.winrateToHandicap(move.winrate));
                         } else {
                             text=String.format("%.1f", roundedWinrate);

--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -202,6 +202,10 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
             case VK_F:
                 Lizzie.config.toggleShowNextMoves();
                 break;
+
+            case VK_H:
+                Lizzie.config.toggleHandicapInsteadOfWinrate();
+                break;
                 
             case VK_PAGE_UP:
                 undo(10);

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -520,7 +520,7 @@ public class LizzieFrame extends JFrame {
         // Last move
         if (validLastWinrate && validWinrate) {
         	String text;
-            if( Lizzie.config.config.getJSONObject("ui").getBoolean("handicap-instead-of-winrate") ) {
+            if(Lizzie.config.handicapInsteadOfWinrate) {
             	text=String.format(": %.2f", Lizzie.leelaz.winrateToHandicap(100-curWR) - Lizzie.leelaz.winrateToHandicap(lastWR));
         	} else {
                 text=String.format(": %.1f%%", 100 - lastWR - curWR);

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -83,6 +83,7 @@ public class LizzieFrame extends JFrame {
     public boolean showCoordinates = false;
     public boolean isPlayingAgainstLeelaz = false;
     public boolean playerIsBlack = true;
+    public int winRateGridLines = 3;
 
     // Get the font name in current system locale
     private String systemDefaultFontName = new JLabel().getFont().getFontName();
@@ -567,8 +568,10 @@ public class LizzieFrame extends JFrame {
                                             new float[]{4}, 0);
             g.setStroke(dashed);
 
-            int middleX = barPosxB + (int) (maxBarwidth / 2);
-            g.drawLine(middleX, barPosY, middleX, barPosY + barHeight);
+            for (int i = 1; i <= winRateGridLines; i++) {
+                int x = barPosxB + (int) (i * (maxBarwidth / (winRateGridLines + 1)));
+                g.drawLine(x, barPosY, x, barPosY + barHeight);
+            }
             g.setStroke(oldstroke);
         }
     }

--- a/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
@@ -48,7 +48,12 @@ public class WinrateGraph {
         g.setStroke(dashed);
 
         g.setColor(Color.white);
-        g.drawLine(posx, posy + height/2, posx + width, posy + height/2);
+        int winRateGridLines = Lizzie.frame.winRateGridLines;
+        for (int i = 1; i <= winRateGridLines; i++) {
+            double percent = i * 100.0 / (winRateGridLines + 1);
+            int y = posy + height - (int) (height * convertWinrate(percent) / 100);
+            g.drawLine(posx, y, posx + width, y);
+        }
 
         g.setColor(Color.green);
         g.setStroke(new BasicStroke(3));
@@ -121,16 +126,16 @@ public class WinrateGraph {
 
                 if (lastOkMove > 0) {
                     g.drawLine(posx + (lastOkMove * width / numMoves),
-                            posy + height - (int) (lastWr * height / 100),
+                            posy + height - (int) (convertWinrate(lastWr) * height / 100),
                             posx + (movenum * width / numMoves),
-                            posy + height - (int) (wr * height / 100));
+                            posy + height - (int) (convertWinrate(wr) * height / 100));
                 }
 
                 if (storedMoveNumber >= 0 ? movenum == storedMoveNumber - 1 : node == curMove)
                 {
                     g.setColor(Color.green);
                     g.fillOval(posx + (movenum*width/numMoves) - DOT_RADIUS,
-                            posy + height - (int)(wr*height/100) - DOT_RADIUS,
+                            posy + height - (int)(convertWinrate(wr)*height/100) - DOT_RADIUS,
                             DOT_RADIUS*2,
                             DOT_RADIUS*2);
                 }
@@ -164,6 +169,19 @@ public class WinrateGraph {
         params[2] = width;
         params[3] = height;
         params[4] = numMoves;
+    }
+
+    private double convertWinrate(double winrate) {
+        double maxHandicap = 10;
+        if (Lizzie.config.config.getJSONObject("ui").getBoolean("handicap-instead-of-winrate")) {
+            double handicap = Lizzie.leelaz.winrateToHandicap(winrate);
+            // handicap == + maxHandicap => r == 1.0
+            // handicap == - maxHandicap => r == 0.0
+            double r = 0.5 + handicap / (2 * maxHandicap);
+            return Math.max(0, Math.min(r, 1)) * 100;
+        } else {
+            return winrate;
+        }
     }
 
     public int moveNumber(int x, int y)

--- a/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
@@ -173,7 +173,7 @@ public class WinrateGraph {
 
     private double convertWinrate(double winrate) {
         double maxHandicap = 10;
-        if (Lizzie.config.config.getJSONObject("ui").getBoolean("handicap-instead-of-winrate")) {
+        if (Lizzie.config.handicapInsteadOfWinrate) {
             double handicap = Lizzie.leelaz.winrateToHandicap(winrate);
             // handicap == + maxHandicap => r == 1.0
             // handicap == - maxHandicap => r == 0.0


### PR DESCRIPTION
I applied #184 to the winrate graph.  See the pictures in my comment
at #184 for its effect.  I also added a hotkey "h" to toggle it
conveniently, though we already have so many toggle keys...

Please feel free to change "winRateGridLines" in LizzieFrame.java and
"maxHandicap" in WinrateGraph.java.  They are the number of grid lines
and the vertical range of the winrate graph.
