### PR TITLE
Fix #154 (Handicap stones are not removed)

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -209,7 +209,7 @@ public class BoardRenderer {
                 }
             }
 
-            cachedZhash = Lizzie.board.getData().zobrist;
+            cachedZhash = Lizzie.board.getData().zobrist.clone();
             g.dispose();
             gShadow.dispose();
             lastInScoreMode = false;

--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -25,6 +25,13 @@ public class Board implements LeelazListener {
 
 
     public Board() {
+        initialize();
+    }
+
+    /**
+     * Initialize the board completely
+     */
+    private void initialize() {
         Stone[] stones = new Stone[BOARD_SIZE * BOARD_SIZE];
         for (int i = 0; i < stones.length; i++)
             stones[i] = Stone.EMPTY;
@@ -691,11 +698,10 @@ public class Board implements LeelazListener {
     }
 
     /**
-     * Clears all history and starts over.
+     * Clears all history and starts over from empty board.
      */
     public void clear() {
-        while (previousMove());
-        history.clear();
+        initialize();
     }
 
     /**

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
@@ -131,6 +131,7 @@ public class BoardHistoryList {
     public void setStone(int[] coordinates, Stone stone) {
         int index = Board.getIndex(coordinates[0], coordinates[1]);
         head.getData().stones[index] = stone;
+        head.getData().zobrist.toggleStone(coordinates[0], coordinates[1], stone);
     }
 
     public Stone[] getStones() {


### PR DESCRIPTION
The first commit fixes #154 (Handicap stones are not removed).

The second commit fixes another related issue:

1. Start Lizzie.
2. Hit "n" key (new game)
3. Input "4" on Handicap field and click "OK".

I expect four black stones appear on the board immediately.
But the board is empty until leelaz puts the first white stone.

We have three problems about handicap stones.

1. Data in the root node is never cleared.
2. Zobrist hash is not updated for handicap stones.
3. Same Zobrist object is owned jointly by a node and Boardrenderer's cache. Even if we update zhash of a node, Boardrenderer's cache is also updated and they are still "equal".
