### PR TITLE
Draw vertical line at current move in winrate graph

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
@@ -97,7 +97,8 @@ public class WinrateGraph {
                     wr = bwr;
                     playouts = stats.totalPlayouts;
                 }
-                if (storedMoveNumber >= 0) {
+                {
+                    // Draw a vertical line at the current move
                     Stroke previousStroke = g.getStroke();
                     int x = posx + (movenum*width/numMoves);
                     g.setStroke(dashed);


### PR DESCRIPTION
I occasionally miss the current position in the winrate graph.  How
about drawing a vertical line at the current move in the graph?  It is
consistent to the UI of mouse-hovering and clicking on the graph.
