### PR TITLE
Clear leelaz's board before loading/pasting SGF

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -146,7 +146,6 @@ public class LizzieFrame extends JFrame {
         if (newGameDialog.isCancelled()) return;
 
         Lizzie.board.clear();
-        Lizzie.leelaz.sendCommand("clear_board");
         Lizzie.leelaz.sendCommand("komi " + gameInfo.getKomi());
 
         Lizzie.leelaz.sendCommand("time_settings 0 " + Lizzie.config.config.getJSONObject("leelaz").getInt("max-game-thinking-time-seconds") + " 1");

--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -701,6 +701,7 @@ public class Board implements LeelazListener {
      * Clears all history and starts over from empty board.
      */
     public void clear() {
+        Lizzie.leelaz.sendCommand("clear_board");
         initialize();
     }
 


### PR DESCRIPTION
1. Start Lizzie
2. Hit "c" key (coordinates on)
3. Hit Ctrl-c key (copy SGF)
4. Click D16 (black)
5. Hit Ctrl-v key (paste SGF)

Then the board is empty. But candidate moves of leelaz appear asymmetrically
(no candidate around D16 as if we had an invisible black stone there).

This commit fixes it by sending "clear_board" to leelaz before loading/pasting SGF.
