### PR TITLE
Empty the board by DEL key at the root node

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -681,8 +681,11 @@ public class Board implements LeelazListener {
                 }
 
             }
-            // Don't try to delete if we're at the top
-            if (curNode.previous() == null) return;
+            // Clear the board if we're at the top
+            if (curNode.previous() == null) {
+                clear();
+                return;
+            }
             previousMove();
             int idx = BoardHistoryList.findIndexOfNode(curNode.previous(), curNode);
             curNode.previous().deleteChild(idx);


### PR DESCRIPTION
Lizzie ignores DEL key at the root node currently.  With this patch,
Lizzie deletes everything instead.

My real aim of this patch is giving users an intuitive way to
delete handicap stones after a handicapped game.  Otherwise, users
have to start a new game with no handicap to delete previous handicap
stones.

This patch also gives a way to recover from #201.
