### PR TITLE
Fix mouse-click behavior of winrate graph

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -649,7 +649,7 @@ public class LizzieFrame extends JFrame {
         }
         if (Lizzie.config.showWinrate && moveNumber >= 0) {
             isPlayingAgainstLeelaz = false;
-            Lizzie.board.goToMoveNumber(moveNumber);
+            Lizzie.board.goToMoveNumberBeyondBranch(moveNumber);
             storeMoveNumber();
         }
         repaint();

--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -433,6 +433,15 @@ public class Board implements LeelazListener {
         return goToMoveNumberHelper(moveNumber, true);
     }
 
+    public boolean goToMoveNumberBeyondBranch(int moveNumber) {
+        // Go to main trunk if current branch is shorter than moveNumber.
+        if (moveNumber > history.currentBranchLength() &&
+            moveNumber <= history.mainTrunkLength()) {
+            goToMoveNumber(0);
+        }
+        return goToMoveNumber(moveNumber);
+    }
+
     public boolean goToMoveNumberHelper(int moveNumber, boolean withinBranch) {
         int delta = moveNumber - history.getMoveNumber();
         boolean moved = false;

--- a/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/BoardHistoryList.java
@@ -194,6 +194,37 @@ public class BoardHistoryList {
         return false;
     }
 
+    /**
+     * Returns the root node
+     *
+     * @return root node
+     */
+    public BoardHistoryNode root() {
+        BoardHistoryNode top = head;
+        while (top.previous() != null) {
+            top = top.previous();
+        }
+        return top;
+    }
+
+    /**
+     * Returns the length of current branch
+     *
+     * @return length of current branch
+     */
+    public int currentBranchLength() {
+        return getMoveNumber() + BoardHistoryList.getDepth(head);
+    }
+
+    /**
+     * Returns the length of main trunk
+     *
+     * @return length of main trunk
+     */
+    public int mainTrunkLength() {
+        return BoardHistoryList.getDepth(root());
+    }
+
     /*
      * Static helper methods
      */


### PR DESCRIPTION
When we are on a variation (length N) that is shorter than the main
trunk, we have no action for a click in the winrate graph if the
clicked point corresponds to a move > N.  I prefer showing the
corresponding move in the main trunk instead.
