### PR TITLE
Don't cancel hotkey actions on winrate graph

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -132,6 +132,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
     @Override
     public void keyPressed(KeyEvent e) {
 
+        Lizzie.frame.beginIntentionalAction();
         PluginManager.onKeyPressed(e);
 
         switch (e.getKeyCode()) {
@@ -257,7 +258,6 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                     Lizzie.frame.drawControls();
                 }
                 Lizzie.frame.showControls = true;
-                Lizzie.frame.repaint();
                 break;
 
             case VK_W:
@@ -292,7 +292,6 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
 
             case VK_Z:
                 Lizzie.config.showRawBoard = true;
-                Lizzie.frame.repaint();
                 break;
 
             case VK_A:
@@ -308,7 +307,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
 
             default:
         }
-        Lizzie.frame.repaint();
+        Lizzie.frame.endIntentionalAction();
     }
 
     private boolean wasPonderingWhenControlsShown = false;
@@ -334,10 +333,12 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
 
     @Override
     public void mouseWheelMoved(MouseWheelEvent e) {
+        Lizzie.frame.beginIntentionalAction();
         if (e.getWheelRotation() > 0) {
             redo();
         } else if (e.getWheelRotation() < 0) {
             undo();
         }
+        Lizzie.frame.endIntentionalAction();
     }
 }

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -18,6 +18,7 @@ import wagner.stephanie.lizzie.analysis.GameInfo;
 import wagner.stephanie.lizzie.analysis.Leelaz;
 import wagner.stephanie.lizzie.rules.Board;
 import wagner.stephanie.lizzie.rules.BoardData;
+import wagner.stephanie.lizzie.rules.BoardHistoryNode;
 import wagner.stephanie.lizzie.rules.GIBParser;
 import wagner.stephanie.lizzie.rules.SGFParser;
 
@@ -85,6 +86,8 @@ public class LizzieFrame extends JFrame {
     public boolean isPlayingAgainstLeelaz = false;
     public boolean playerIsBlack = true;
     public int winRateGridLines = 3;
+
+    private BoardHistoryNode nodeBeforeIntentionalAction = null;
 
     // Get the font name in current system locale
     private String systemDefaultFontName = new JLabel().getFont().getFontName();
@@ -701,10 +704,14 @@ public class LizzieFrame extends JFrame {
     private boolean tryRestoreMoveNumber() {
         if (winrateGraph.storedMoveNumber >= 0) {
             Lizzie.board.goToMoveNumber(winrateGraph.storedMoveNumber);
-            winrateGraph.storedMoveNumber = -1;
+            discardStoredMoveNumber();
             return true;
         }
         return false;
+    }
+
+    private void discardStoredMoveNumber() {
+        winrateGraph.storedMoveNumber = -1;
     }
 
     public void toggleCoordinates() {
@@ -750,5 +757,20 @@ public class LizzieFrame extends JFrame {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    public void beginIntentionalAction() {
+        // We need to detect "intentional" changes of the board
+        // for the winrate graph.
+        // Changes caused by mouse hover are temporal,
+        // whereas intentional changes are permanent.
+        nodeBeforeIntentionalAction = Lizzie.board.getHistory().getCurrentHistoryNode();
+    }
+
+    public void endIntentionalAction() {
+        if (Lizzie.board.getHistory().getCurrentHistoryNode() != nodeBeforeIntentionalAction) {
+            discardStoredMoveNumber();
+        }
+        repaint();
     }
 }


### PR DESCRIPTION
If we type Up/Down arrow keys while the mouse pointer is in the
winrate graph, their actions are canceled and the previous board is
restored when the pointer leaves the graph.  I expect that such
"intentional" actions should be permanent, whereas mouse-hover actions
are temporal.
