### PR TITLE
Show move number in winrate graph

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/WinrateGraph.java
@@ -105,6 +105,12 @@ public class WinrateGraph {
                     g.setStroke(dashed);
                     g.setColor(Color.white);
                     g.drawLine(x, posy, x, posy + height);
+                    // Show move number
+                    String moveNumString = "" + node.getData().moveNumber;
+                    int mw = g.getFontMetrics().stringWidth(moveNumString);
+                    int margin = strokeRadius;
+                    int mx = x - posx < width / 2 ? x + margin : x - mw - margin;
+                    g.drawString(moveNumString, mx, posy + height - margin);
                     g.setStroke(previousStroke);
                 }
             }


### PR DESCRIPTION
We can jump to the Nth move quickly by clicking the winrate graph
if we show the move number there.
