### PR TITLE
Fix: failsafe mode failed to parse "pass" in pondering output

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
+++ b/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
@@ -265,7 +265,7 @@ public class Leelaz {
 
     private void parseLineFailSafe(String line) {
         synchronized (this) {
-            boolean isMoveDataLine = line.matches("(?s) +[A-T][0-9]+ -> +[0-9].*");
+            boolean isMoveDataLine = line.matches("(?s) *([A-T][0-9]+|pass) -> +[0-9].*");
             if (!isReadingPonderOutput && isMoveDataLine && !isWaitingToStartPonder) {
                 if (System.currentTimeMillis() - startPonderTime > maxAnalyzeTimeMillis) {
                     // we have pondered for enough time. pause pondering


### PR DESCRIPTION
It caused wrong winrate and wrong suggestion display when a game is almost over.