### PR TITLE
Print all lines from leelaz if "print-comms" is true

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
+++ b/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
@@ -191,6 +191,9 @@ public class Leelaz {
      * @param line output line
      */
     private void parseLine(String line) {
+        if (printCommunication) {
+            System.out.print(line);
+        }
         if (failSafeMode) {
             parseLineFailSafe(line);
         } else {
@@ -230,10 +233,6 @@ public class Leelaz {
                         }
                     }
                 } else {
-                    if (printCommunication) {
-                        System.out.print(line);
-                    }
-
                     line = line.trim();
                     if (Lizzie.frame != null && line.startsWith("=") && line.length() > 2) {
 
@@ -290,10 +289,6 @@ public class Leelaz {
                 if (isReadingPonderOutput && !isWaitingToStartPonder) {
                     parseMoveDataLine(line);
                 } else {
-                    if (printCommunication) {
-                        System.out.print(line);
-                    }
-
                     line = line.trim();
                     if (Lizzie.frame != null && line.startsWith("=") && line.length() > 2) {
 


### PR DESCRIPTION
I hope to watch all lines from leelaz for debugging (e.g. #216).
Do you have a reason to hide some lines?
