### PR TITLE
Fix NumberFormatException at Enter key in failsafe mode

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
+++ b/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
@@ -311,10 +311,10 @@ public class Leelaz {
                             }
                             isSettingHandicap = false;
                         } else if (isThinking) {
-                            if (Lizzie.frame.isPlayingAgainstLeelaz) {
+                            if (Lizzie.frame.isPlayingAgainstLeelaz && line.matches("(?s)= ([A-T][0-9]+|pass).*")) {
                                 Lizzie.board.place(line.substring(2));
+                                isThinking = false;
                             }
-                            isThinking = false;
                         }
                     }
                 }


### PR DESCRIPTION
1. Make the original leela-zero-0.14 ready.
2. Start Lizzie (in failsafe mode)
3. Hit Enter key

Then I get an error.

    > time_settings 0 2 1
    > genmove B
    
    > time_left b 0 0
    49 non leaf nodes, 1.47 average children
    
    73 visits, 26227 nodes
    
    = Leela Zero
    Exception in thread "Thread-3" java.lang.NumberFormatException: For input string: "eela Zero"
            at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
            at java.lang.Integer.parseInt(Integer.java:580)
            at java.lang.Integer.parseInt(Integer.java:615)
            at wagner.stephanie.lizzie.rules.Board.convertNameToCoordinates(Board.java:70)
            at wagner.stephanie.lizzie.rules.Board.place(Board.java:271)
            at wagner.stephanie.lizzie.analysis.Leelaz.parseLineFailSafe(Leelaz.java:315)
            at wagner.stephanie.lizzie.analysis.Leelaz.parseLine(Leelaz.java:195)
            at wagner.stephanie.lizzie.analysis.Leelaz.read(Leelaz.java:373)
            at java.lang.Thread.run(Thread.java:745)
    > name

    $ git log --oneline | head -n 1
    4653f4e Merge pull request #218 from kaorahi/graph_drag
