### PR TITLE
Enhance Z key feature (show raw board)

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -70,6 +70,9 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
         if (Lizzie.frame.isPlayingAgainstLeelaz) {
             Lizzie.frame.isPlayingAgainstLeelaz = false;
         }
+        if (Lizzie.frame.incrementDisplayedBranchLength(- movesToAdvance)) {
+            return;
+        }
 
         for (int i = 0; i < movesToAdvance; i++)
             Lizzie.board.previousMove();
@@ -93,6 +96,9 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
     private void redo(int movesToAdvance) {
         if (Lizzie.frame.isPlayingAgainstLeelaz) {
             Lizzie.frame.isPlayingAgainstLeelaz = false;
+        }
+        if (Lizzie.frame.incrementDisplayedBranchLength(movesToAdvance)) {
+            return;
         }
 
         for (int i = 0; i < movesToAdvance; i++)
@@ -299,6 +305,9 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
 
             case VK_Z:
+                if (!Lizzie.config.showRawBoard) {
+                    Lizzie.frame.startRawBoard();
+                }
                 Lizzie.config.showRawBoard = true;
                 break;
 
@@ -331,6 +340,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
 
             case VK_Z:
+                Lizzie.frame.stopRawBoard();
                 Lizzie.config.showRawBoard = false;
                 Lizzie.frame.repaint();
                 break;

--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -105,6 +105,23 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
             Lizzie.board.nextMove();
     }
 
+    private void startRawBoard() {
+        if (!Lizzie.config.showRawBoard) {
+            Lizzie.frame.startRawBoard();
+        }
+        Lizzie.config.showRawBoard = true;
+    }
+
+    private void stopRawBoard() {
+        Lizzie.frame.stopRawBoard();
+        Lizzie.config.showRawBoard = false;
+    }
+
+    private void toggleHints() {
+        Lizzie.config.toggleShowBranch();
+        Lizzie.config.showNextMoves = Lizzie.config.showBestMoves = Lizzie.config.showBranch;
+    }
+
     private void nextBranch() {
         if (Lizzie.frame.isPlayingAgainstLeelaz) {
             Lizzie.frame.isPlayingAgainstLeelaz = false;
@@ -305,10 +322,11 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
 
             case VK_Z:
-                if (!Lizzie.config.showRawBoard) {
-                    Lizzie.frame.startRawBoard();
+                if (e.isShiftDown()) {
+                    toggleHints();
+                } else {
+                    startRawBoard();
                 }
-                Lizzie.config.showRawBoard = true;
                 break;
 
             case VK_A:
@@ -340,8 +358,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
 
             case VK_Z:
-                Lizzie.frame.stopRawBoard();
-                Lizzie.config.showRawBoard = false;
+                stopRawBoard();
                 Lizzie.frame.repaint();
                 break;
 

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -695,6 +695,23 @@ public class LizzieFrame extends JFrame {
                 whitePlayer, blackPlayer));
     }
 
+    private void setDisplayedBranchLength(int n) {
+        boardRenderer.setDisplayedBranchLength(n);
+    }
+
+    public void startRawBoard() {
+        boolean onBranch = boardRenderer.isShowingBranch();
+        int n = (onBranch ? 1 : BoardRenderer.SHOW_RAW_BOARD);
+        boardRenderer.setDisplayedBranchLength(n);
+    }
+
+    public void stopRawBoard() {
+        boardRenderer.setDisplayedBranchLength(BoardRenderer.SHOW_NORMAL_BOARD);
+    }
+
+    public boolean incrementDisplayedBranchLength(int n) {
+        return boardRenderer.incrementDisplayedBranchLength(n);
+    }
 
     public void copySgf() {
         try {


### PR DESCRIPTION
(First commit)
This patch enhances the behavior of Z key (show raw board).  Holding Z
key on a suggested move of leelaz, we see only the move numbers
(without stones) of the variation.  Up arrow key hides these move
numbers, and Down arrow key shows stones one by one.  I think this is
useful for watching complicated variations.

(Second commit)
Shift-Z toggles showNextMoves, showBestMoves, and showBranch at once.
I intend to use Lizzie as a training tool with this no-hint view and #222 (Play the best move).
