### PR TITLE
Don't abort auto-analysis. Ignore empty notifications instead.

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -1020,8 +1020,7 @@ public class Board implements LeelazListener {
     public void bestMoveNotification(List<MoveData> bestMoves) {
         if (analysisMode) {
             if (bestMoves == null || bestMoves.size() == 0) {
-                // If we get empty list, something strange happened, abort analysis
-                toggleAnalysis();
+                // If we get empty list, something strange happened, ignore notification
             } else if (bestMoves.get(0).playouts > playoutsAnalysis) {
                 if (!nextMove()) {
                     // Reached the end...


### PR DESCRIPTION
Auto-analysis is often aborted on my slow machine (every 3-10 moves).
How about ignoring empty notifications instead of aborting auto-analysis?
