### PR TITLE
Fix: auto-analysis did not stop if the last two moves are "pass"

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -1020,13 +1020,18 @@ public class Board implements LeelazListener {
 
     public void bestMoveNotification(List<MoveData> bestMoves) {
         if (analysisMode) {
-            if (bestMoves == null || bestMoves.size() == 0) {
+            boolean isSuccessivePass = (history.getPrevious() != null &&
+                                        history.getPrevious().lastMove == null &&
+                                        getLastMove() == null);
+            // Note: We cannot replace this history.getNext() with getNextMove()
+            // because the latter returns null if the next move is "pass".
+            if (history.getNext() == null || isSuccessivePass) {
+                // Reached the end...
+                toggleAnalysis();
+            } else if (bestMoves == null || bestMoves.size() == 0) {
                 // If we get empty list, something strange happened, ignore notification
             } else if (bestMoves.get(0).playouts > playoutsAnalysis) {
-                if (!nextMove()) {
-                    // Reached the end...
-                    toggleAnalysis();
-                }
+                nextMove();
             }
         }
     }


### PR DESCRIPTION
I overlooked a side effect of #227.