### PR TITLE
Add subboard that always shows the principal variation

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -19,6 +19,7 @@ public class Config {
     public boolean showBestMoves = true;
     public boolean showNextMoves = true;
     public boolean showSubBoard = true;
+    public boolean largeSubBoard = false;
     
     public JSONObject config;
     public JSONObject persisted;
@@ -76,6 +77,7 @@ public class Config {
         showBestMoves = uiConfig.getBoolean("show-best-moves");
         showNextMoves = uiConfig.getBoolean("show-next-moves");
         showSubBoard = uiConfig.getBoolean("show-subboard");
+        largeSubBoard = uiConfig.getBoolean("large-subboard");
         handicapInsteadOfWinrate = uiConfig.getBoolean("handicap-instead-of-winrate");
     }
 
@@ -125,6 +127,10 @@ public class Config {
     public void toggleHandicapInsteadOfWinrate() {
         this.handicapInsteadOfWinrate = !this.handicapInsteadOfWinrate;
     }
+    public boolean showLargeSubBoard() {
+        return showSubBoard && largeSubBoard;
+    }
+
 
 
 
@@ -158,6 +164,7 @@ public class Config {
         ui.put("show-best-moves", true);
         ui.put("show-next-moves", true);
         ui.put("show-subboard", true);
+        ui.put("large-subboard", false);
         ui.put("win-rate-always-black", false);
         ui.put("confirm-exit", false);
         ui.put("handicap-instead-of-winrate",false);

--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -127,6 +127,9 @@ public class Config {
     public void toggleHandicapInsteadOfWinrate() {
         this.handicapInsteadOfWinrate = !this.handicapInsteadOfWinrate;
     }
+    public void toggleLargeSubBoard() {
+        this.largeSubBoard = !this.largeSubBoard;
+    }
     public boolean showLargeSubBoard() {
         return showSubBoard && largeSubBoard;
     }

--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -18,6 +18,7 @@ public class Config {
 
     public boolean showBestMoves = true;
     public boolean showNextMoves = true;
+    public boolean showSubBoard = true;
     
     public JSONObject config;
     public JSONObject persisted;
@@ -74,6 +75,7 @@ public class Config {
         showVariationGraph = uiConfig.getBoolean("show-variation-graph");
         showBestMoves = uiConfig.getBoolean("show-best-moves");
         showNextMoves = uiConfig.getBoolean("show-next-moves");
+        showSubBoard = uiConfig.getBoolean("show-subboard");
         handicapInsteadOfWinrate = uiConfig.getBoolean("handicap-instead-of-winrate");
     }
 
@@ -155,6 +157,7 @@ public class Config {
         ui.put("show-variation-graph", true);
         ui.put("show-best-moves", true);
         ui.put("show-next-moves", true);
+        ui.put("show-subboard", true);
         ui.put("win-rate-always-black", false);
         ui.put("confirm-exit", false);
         ui.put("handicap-instead-of-winrate",false);

--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -484,7 +484,7 @@ public class BoardRenderer {
                     float brightness = 0.85f; //brightness
                     int alpha = (int) (MIN_ALPHA + (MAX_ALPHA - MIN_ALPHA) * Math.max(0, Math.log(percentPlayouts) /
                             ALPHA_SCALING_FACTOR + 1));
-//                    if (uiConfig.getBoolean("shadows-enabled"))
+//                    if (uiConfig.getBoolean("shadows-enabled") && isMainBoard)
 //                        alpha = 255;
 
                     Color hsbColor = Color.getHSBColor(hue, saturation, brightness);
@@ -555,7 +555,7 @@ public class BoardRenderer {
     }
 
     private void drawWoodenBoard(Graphics2D g) {
-        if (uiConfig.getBoolean("fancy-board")) {
+        if (uiConfig.getBoolean("fancy-board") && isMainBoard) {
             // fancy version
             int shadowRadius = (int) (boardLength * MARGIN / 6);
             Image boardImage = theme.getBoard();
@@ -608,7 +608,7 @@ public class BoardRenderer {
     }
 
     private void drawShadow(Graphics2D g, int centerX, int centerY, boolean isGhost, float shadowStrength) {
-        if (!uiConfig.getBoolean("shadows-enabled"))
+        if (!uiConfig.getBoolean("shadows-enabled") || !isMainBoard)
             return;
 
         final int shadowSize = (int) (stoneRadius * 0.3 * uiConfig.getInt("shadow-size") / 100);
@@ -668,7 +668,7 @@ public class BoardRenderer {
         switch (color) {
             case BLACK:
             case BLACK_CAPTURED:
-                if (uiConfig.getBoolean("fancy-stones")) {
+                if (useFancyStones()) {
                     drawShadow(gShadow, centerX, centerY, false);
                     Image stone = theme.getBlackStone(new int[]{x, y});
                     g.drawImage(stone, centerX - stoneRadius, centerY - stoneRadius, stoneRadius * 2 + 1, stoneRadius * 2 + 1, null);
@@ -681,7 +681,7 @@ public class BoardRenderer {
 
             case WHITE:
             case WHITE_CAPTURED:
-                if (uiConfig.getBoolean("fancy-stones")) {
+                if (useFancyStones()) {
                     drawShadow(gShadow, centerX, centerY, false);
                     Image stone = theme.getWhiteStone(new int[]{x, y});
                     g.drawImage(stone, centerX - stoneRadius, centerY - stoneRadius, stoneRadius * 2 + 1, stoneRadius * 2 + 1, null);
@@ -695,7 +695,7 @@ public class BoardRenderer {
                 break;
 
             case BLACK_GHOST:
-                if (uiConfig.getBoolean("fancy-stones")) {
+                if (useFancyStones()) {
                     drawShadow(gShadow, centerX, centerY, true);
                     Image stone = theme.getBlackStone(new int[]{x, y});
                     g.drawImage(stone, centerX - stoneRadius, centerY - stoneRadius, stoneRadius * 2 + 1, stoneRadius * 2 + 1, null);
@@ -707,7 +707,7 @@ public class BoardRenderer {
                 break;
 
             case WHITE_GHOST:
-                if (uiConfig.getBoolean("fancy-stones")) {
+                if (useFancyStones()) {
                     drawShadow(gShadow, centerX, centerY, true);
                     Image stone = theme.getWhiteStone(new int[]{x, y});
                     g.drawImage(stone, centerX - stoneRadius, centerY - stoneRadius, stoneRadius * 2 + 1, stoneRadius * 2 + 1, null);
@@ -923,5 +923,9 @@ public class BoardRenderer {
 
     private boolean showCoordinates() {
         return isMainBoard && Lizzie.frame.showCoordinates;
+    }
+
+    private boolean useFancyStones() {
+        return uiConfig.getBoolean("fancy-stones") && isMainBoard;
     }
 }

--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -921,6 +921,10 @@ public class BoardRenderer {
         }
     }
 
+    public boolean isInside(int x1, int y1) {
+        return (x <= x1 && x1 < x + boardLength && y <= y1 && y1 < y + boardLength);
+    }
+
     private boolean showCoordinates() {
         return isMainBoard && Lizzie.frame.showCoordinates;
     }

--- a/src/main/java/wagner/stephanie/lizzie/gui/Input.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/Input.java
@@ -119,7 +119,8 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
 
     private void toggleHints() {
         Lizzie.config.toggleShowBranch();
-        Lizzie.config.showNextMoves = Lizzie.config.showBestMoves = Lizzie.config.showBranch;
+        Lizzie.config.showSubBoard = Lizzie.config.showNextMoves = Lizzie.config.showBestMoves
+            = Lizzie.config.showBranch;
     }
 
     private void nextBranch() {

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -321,6 +321,43 @@ public class LizzieFrame extends JFrame {
             int subBoardHeight = ponderingY - subBoardY;
             int subBoardLength = Math.min(subBoardWidth, subBoardHeight);
 
+            if (Lizzie.config.showLargeSubBoard()) {
+                boardX = getWidth() - maxSize - panelMargin;
+                int spaceW = boardX - panelMargin;
+                int spaceH = getHeight() - topInset;
+                int panelW = spaceW / 2;
+                int panelH = spaceH / 4;
+                capx = 0;
+                capy = topInset;
+                capw = panelW;
+                caph = (int) (panelH * 0.2);
+                statx = 0;
+                staty = capy + caph;
+                statw = panelW;
+                stath = (int) (panelH * 0.4);
+                grx = statx;
+                gry = staty + stath;
+                grw = statw;
+                grh = panelH - caph - stath;
+                contx = statx;
+                conty = staty;
+                contw = statw;
+                conth = stath + grh;
+                vx = panelW;
+                vy = 0;
+                vw = panelW;
+                vh = topInset + panelH;
+                treex = vx;
+                treey = vy;
+                treew = vw + 1;
+                treeh = vh;
+                subBoardX = 0;
+                subBoardY = topInset + panelH;
+                subBoardWidth = spaceW;
+                subBoardHeight = ponderingY - subBoardY;
+                subBoardLength = Math.min(subBoardWidth, subBoardHeight);
+            }
+
             // initialize
 
             cachedImage = new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_INT_ARGB);
@@ -691,12 +728,15 @@ public class LizzieFrame extends JFrame {
         g.setColor(Color.WHITE);
         int bw = g.getFontMetrics().stringWidth(bval);
         int ww = g.getFontMetrics().stringWidth(wval);
+        boolean largeSubBoard = Lizzie.config.showLargeSubBoard();
+        int bx = (largeSubBoard ? diam : - bw/2);
+        int wx = (largeSubBoard ? bx : - ww/2);
 
         g.drawString(bval,
-                posX + width/4 - bw/2,
+                posX + width/4 + bx,
                 posY + height*7/8);
         g.drawString(wval,
-                posX + width*3/4 - ww/2,
+                posX + width*3/4 + wx,
                 posY + height*7/8);
     }
 

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -269,9 +269,9 @@ public class LizzieFrame extends JFrame {
 
             // move statistics (winrate bar)
             // boardX equals width of space on each side
-            int statx = (int) (boardRenderer.getLocation().x * 0);
+            int statx = 0;
             int staty = boardY + maxSize / 8;
-            int statw = boardRenderer.getLocation().x - statx - panelMargin;
+            int statw = boardX - statx - panelMargin;
             int stath = maxSize / 10;
 
             // winrate graph
@@ -289,11 +289,11 @@ public class LizzieFrame extends JFrame {
             // captured stones
             int capx = 0;
             int capy = this.getInsets().top;
-            int capw = boardRenderer.getLocation().x - (int)(maxSize*0.05);
+            int capw = boardX - (int)(maxSize*0.05);
             int caph = boardY+ maxSize/8 - this.getInsets().top;
 
             // variation tree container
-            int vx = boardRenderer.getLocation().x + boardRenderer.getActualBoardLength() + panelMargin;
+            int vx = boardX + maxSize + panelMargin;
             int vy = 0;
             int vw = getWidth() - vx;
             int vh = getHeight();
@@ -763,6 +763,9 @@ public class LizzieFrame extends JFrame {
         if (Lizzie.config.showWinrate && moveNumber >= 0) {
             isPlayingAgainstLeelaz = false;
             Lizzie.board.goToMoveNumberBeyondBranch(moveNumber);
+        }
+        if (Lizzie.config.showSubBoard && subBoardRenderer.isInside(x, y)) {
+            Lizzie.config.toggleLargeSubBoard();
         }
         repaint();
     }

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -73,6 +73,7 @@ public class LizzieFrame extends JFrame {
     };
     private static final String DEFAULT_TITLE = "Lizzie - Leela Zero Interface";
     private static BoardRenderer boardRenderer;
+    private static BoardRenderer subBoardRenderer;
     private static VariationTree variatonTree;
     private static WinrateGraph winrateGraph;
 
@@ -107,7 +108,8 @@ public class LizzieFrame extends JFrame {
     public LizzieFrame() {
         super(DEFAULT_TITLE);
 
-        boardRenderer = new BoardRenderer();
+        boardRenderer = new BoardRenderer(true);
+        subBoardRenderer = new BoardRenderer(false);
         variatonTree = new VariationTree();
         winrateGraph = new WinrateGraph();
 
@@ -304,13 +306,20 @@ public class LizzieFrame extends JFrame {
 
             // pondering message
             int ponderingX = this.getInsets().left;
-            int ponderingY = boardY + maxSize*2/3;
+            int ponderingY = boardY + (int) (maxSize*0.93);
             double ponderingSize = .02;
 
             // loading message
             int loadingX = ponderingX;
             int loadingY = ponderingY;
             double loadingSize = 0.03;
+
+            // subboard
+            int subBoardX = 0;
+            int subBoardY = gry + grh;
+            int subBoardWidth = grw;
+            int subBoardHeight = ponderingY - subBoardY;
+            int subBoardLength = Math.min(subBoardWidth, subBoardHeight);
 
             // initialize
 
@@ -338,6 +347,15 @@ public class LizzieFrame extends JFrame {
                 if (Lizzie.config.showVariationGraph) {
                     drawVariationTreeContainer(backgroundG, vx, vy, vw, vh);
                     variatonTree.draw(g, treex, treey, treew, treeh);
+                }
+                if (Lizzie.config.showSubBoard) {
+                    try {
+                        subBoardRenderer.setLocation(subBoardX, subBoardY);
+                        subBoardRenderer.setBoardLength(subBoardLength);
+                        subBoardRenderer.draw(g);
+                    } catch (Exception e) {
+                        // This can happen when no space is left for subboard.
+                    }
                 }
             } else {
                 drawPonderingState(g, resourceBundle.getString("LizzieFrame.display.loading"), loadingX, loadingY, loadingSize);

--- a/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/LizzieFrame.java
@@ -253,20 +253,72 @@ public class LizzieFrame extends JFrame {
             backgroundG = null;
 
         if (!showControls) {
+            // layout parameters
+
+            int topInset = this.getInsets().top;
+
+            // board
+            int maxSize = (int) (Math.min(getWidth(), getHeight() - topInset) * 0.98);
+            maxSize = Math.max(maxSize, Board.BOARD_SIZE + 5); // don't let maxWidth become too small
+            int boardX = (getWidth() - maxSize) / 2;
+            int boardY = topInset + (getHeight() - topInset - maxSize) / 2 + 3;
+
+            int panelMargin = (int) (maxSize * 0.05);
+
+            // move statistics (winrate bar)
+            // boardX equals width of space on each side
+            int statx = (int) (boardRenderer.getLocation().x * 0);
+            int staty = boardY + maxSize / 8;
+            int statw = boardRenderer.getLocation().x - statx - panelMargin;
+            int stath = maxSize / 10;
+
+            // winrate graph
+            int grx = statx;
+            int gry = staty + stath;
+            int grw = statw;
+            int grh = statw;
+
+            // graph container
+            int contx = statx;
+            int conty = staty;
+            int contw = statw;
+            int conth = stath;
+
+            // captured stones
+            int capx = 0;
+            int capy = this.getInsets().top;
+            int capw = boardRenderer.getLocation().x - (int)(maxSize*0.05);
+            int caph = boardY+ maxSize/8 - this.getInsets().top;
+
+            // variation tree container
+            int vx = boardRenderer.getLocation().x + boardRenderer.getActualBoardLength() + panelMargin;
+            int vy = 0;
+            int vw = getWidth() - vx;
+            int vh = getHeight();
+
+            // variation tree
+            int treex = vx;
+            int treey = vy;
+            int treew = vw + 1;
+            int treeh = vh;
+
+            // pondering message
+            int ponderingX = this.getInsets().left;
+            int ponderingY = boardY + maxSize*2/3;
+            double ponderingSize = .02;
+
+            // loading message
+            int loadingX = ponderingX;
+            int loadingY = ponderingY;
+            double loadingSize = 0.03;
+
             // initialize
 
             cachedImage = new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_INT_ARGB);
             Graphics2D g = (Graphics2D) cachedImage.getGraphics();
 
-            int topInset = this.getInsets().top;
-
-            int maxSize = (int) (Math.min(getWidth(), getHeight() - topInset) * 0.98);
-            maxSize = Math.max(maxSize, Board.BOARD_SIZE + 5); // don't let maxWidth become too small
-
             drawCommandString(g);
 
-            int boardX = (getWidth() - maxSize) / 2;
-            int boardY = topInset + (getHeight() - topInset - maxSize) / 2 + 3;
             boardRenderer.setLocation(boardX, boardY);
             boardRenderer.setBoardLength(maxSize);
             boardRenderer.draw(g);
@@ -274,37 +326,24 @@ public class LizzieFrame extends JFrame {
             if (Lizzie.leelaz != null) {
                 drawPonderingState(g, resourceBundle.getString("LizzieFrame.display.pondering") +
                         (Lizzie.leelaz.isPondering()?resourceBundle.getString("LizzieFrame.display.on"):resourceBundle.getString("LizzieFrame.display.off")),
-                        this.getInsets().left, boardY + maxSize*2/3, .02);
+                        ponderingX, ponderingY, ponderingSize);
 
-                int panelMargin = (int) (maxSize * 0.05);
                 // Todo: Make board move over when there is no space beside the board
                 if (Lizzie.config.showWinrate) {
-                    // boardX equals width of space on each side
-                    int statx = (int) (boardRenderer.getLocation().x * 0);
-                    int staty = boardY + maxSize / 8;
-                    int statw = boardRenderer.getLocation().x - statx - panelMargin;
-                    int stath = maxSize / 10;
-
-                    drawWinrateGraphContainer(backgroundG, statx, staty, statw, stath);
+                    drawWinrateGraphContainer(backgroundG, contx, conty, contw, conth);
                     drawMoveStatistics(g, statx, staty, statw, stath);
-                    winrateGraph.draw(g, statx, staty + stath, statw, statw);
+                    winrateGraph.draw(g, grx, gry, grw, grh);
                 }
 
                 if (Lizzie.config.showVariationGraph) {
-                    int vx = boardRenderer.getLocation().x + boardRenderer.getActualBoardLength() + panelMargin;
-                    int vy = 0;
-                    int vw = getWidth() - vx;
-                    int vh = getHeight();
-
                     drawVariationTreeContainer(backgroundG, vx, vy, vw, vh);
-                    variatonTree.draw(g, vx, 0, getWidth() - vx + 1, getHeight());
+                    variatonTree.draw(g, treex, treey, treew, treeh);
                 }
             } else {
-                drawPonderingState(g, resourceBundle.getString("LizzieFrame.display.loading"),this.getInsets().left,
-                        boardY + maxSize*2/3,0.03);
+                drawPonderingState(g, resourceBundle.getString("LizzieFrame.display.loading"), loadingX, loadingY, loadingSize);
             }
 
-            drawCaptured(g, 0, this.getInsets().top, boardRenderer.getLocation().x - (int)(maxSize*0.05), boardY+ maxSize/8 - this.getInsets().top);
+            drawCaptured(g, capx, capy, capw, caph);
 
             // cleanup
             g.dispose();

--- a/src/main/java/wagner/stephanie/lizzie/gui/VariationTree.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/VariationTree.java
@@ -9,8 +9,8 @@ import java.util.ArrayList;
 
 public class VariationTree {
 
-    private int YSPACING = 30;
-    private int XSPACING = 30;
+    private int YSPACING;
+    private int XSPACING;
     private int DOT_DIAM = 11; // Should be odd number
 
     private ArrayList<Integer> laneUsageList;
@@ -109,6 +109,10 @@ public class VariationTree {
     public void draw(Graphics2D g, int posx, int posy, int width, int height) {
         if (width <= 0 || height <= 0)
             return; // we don't have enough space
+
+        // Use dense tree for saving space if large-subboard
+        YSPACING = (Lizzie.config.showLargeSubBoard() ? 20 : 30);
+        XSPACING = YSPACING;
 
         // Draw background
         g.setColor(new Color(0, 0, 0, 60));


### PR DESCRIPTION
I feel that zero-click UI is the key invention of Lizzie.  It makes
analyses of games much fun.  I had never imagined that the difference
between 1-click and 0-click is so large until I experienced it by
myself.

Along this direction, I added a subboard that always shows the
principal variation.  We do not need even mouse-hovering to see it.
It is hidden by shift-Z key (no-hint view in #223) and enlarged by
mouse click on it.  I also added "show-subboard" and "large-subboard"
into lizzie.properties.

Of course this feature is entirely redundant.  But I think that "can
do" and "can do with no action" is different.

Though this PR is rather large, half of changed lines are mere layout
parameters.

![subboard1](https://user-images.githubusercontent.com/38910552/40492340-3b1acb6c-5fab-11e8-91e5-346865f65e7c.jpg)
![subboard2](https://user-images.githubusercontent.com/38910552/40492378-4fec0114-5fab-11e8-868d-a5d21c756d90.jpg)
