### PR TITLE
Fix SGF issues (escaping, MultiGo postprocess)

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/rules/SGFParser.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/SGFParser.java
@@ -74,6 +74,7 @@ public class SGFParser {
 
         String blackPlayer = "", whitePlayer = "";
 
+        PARSE_LOOP:
         for (byte b : value.getBytes()) {
             // Check unicode charactors (UTF-8)
             char c = (char) b;
@@ -97,7 +98,7 @@ public class SGFParser {
                     if (!inTag) {
                         subTreeDepth -= 1;
                         if (isMultiGo) {
-                            return true;
+                            break PARSE_LOOP;
                         }
                     }
                     break;

--- a/src/main/java/wagner/stephanie/lizzie/rules/SGFParser.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/SGFParser.java
@@ -62,7 +62,7 @@ public class SGFParser {
             return false;
         }
         int subTreeDepth = 0;
-        boolean inTag = false, isMultiGo = false;
+        boolean inTag = false, isMultiGo = false, escaping = false;
         String tag = null;
         StringBuilder tagBuilder = new StringBuilder();
         StringBuilder tagContentBuilder = new StringBuilder();
@@ -78,6 +78,13 @@ public class SGFParser {
             // Check unicode charactors (UTF-8)
             char c = (char) b;
             if (((int) b & 0x80) != 0) {
+                continue;
+            }
+            if (escaping) {
+                // Any char following "\" is inserted verbatim
+                // (ref) "3.2. Text" in https://www.red-bean.com/sgf/sgf4.html
+                tagContentBuilder.append(c);
+                escaping = false;
                 continue;
             }
             switch (c) {
@@ -162,6 +169,10 @@ public class SGFParser {
                         break;
                     }
                     if (inTag) {
+                        if (c == '\\') {
+                            escaping = true;
+                            continue;
+                        }
                         tagContentBuilder.append(c);
                     } else {
                         if (c != '\n' && c != '\r' && c != '\t' && c != ' ') {


### PR DESCRIPTION
These commits fix problems for SGF from http://eidogo.com/#32R1CLyop

(1) Read

    C[foo [3d\]: ...]

as "foo [3d]: ..."

(2) Update window title and rewind to game start after reading SGF

I omitted further exceptional rules in the SGF specification.
See "3.2. Text" in https://www.red-bean.com/sgf/sgf4.html for example.
