### PR TITLE
Preliminary support for 9x9 and 13x13 boards.

### DIFF
--- a/src/main/java/wagner/stephanie/lizzie/Config.java
+++ b/src/main/java/wagner/stephanie/lizzie/Config.java
@@ -3,6 +3,8 @@ package wagner.stephanie.lizzie;
 import org.json.*;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Iterator;
 
 public class Config {
@@ -52,12 +54,66 @@ public class Config {
 
         fp.close();
 
+        // Validate and correct settings
+        if (validateAndCorrectSettings(mergedcfg)) {
+            modified = true;
+        }
+
         if (modified) {
             writeConfig(mergedcfg, file);
         }
         return mergedcfg;
 
 
+    }
+
+    /**
+     * Check settings to ensure its consistency, especially for those whose types are not <code>boolean</code>.
+     * If any inconsistency is found, try to correct it or to report it.
+     * <br>
+     * For example, we only support 9x9, 13x13 or 19x19(default) sized boards. If the configured board size
+     * is not in the list above, we should correct it.
+     *
+     * @param config The config json object to check
+     * @return if any correction has been made.
+     */
+    private boolean validateAndCorrectSettings(JSONObject config) {
+        // We don't care persisted settings. They are managed automatically.
+        if (config == null || !config.has("ui")) {
+            return false;
+        }
+
+        boolean madeCorrections = false;
+
+        // Check ui configs
+        JSONObject ui = config.getJSONObject("ui");
+
+        // Check board-size. We support only 9x9, 13x13 or 19x19
+        int boardSize = ui.optInt("board-size", 19);
+        if (boardSize != 19 && boardSize != 13 && boardSize != 9) {
+            // Correct it to default 19x19
+            ui.put("board-size", 19);
+            madeCorrections = true;
+        }
+
+        // Check engine configs
+        JSONObject leelaz = config.getJSONObject("leelaz");
+        // Check if the engine program exists.
+        String enginePath = leelaz.optString("engine-program", "./leelaz");
+        if (!Files.exists(Paths.get(enginePath)) && !Files.exists(Paths.get(enginePath + ".exe" /* For windows */))) {
+            // FIXME: I don't know how to handle it properly.. Possibly showing a warning dialog may be a good idea?
+            leelaz.put("engine-program", "./leelaz");
+            madeCorrections = true;
+        }
+
+        // Similar checks for startup directory. It should exist and should be a directory.
+        String engineStartLocation = leelaz.optString("engine-start-location", ".");
+        if (!(Files.exists(Paths.get(engineStartLocation)) && Files.isDirectory(Paths.get(engineStartLocation)))) {
+            leelaz.put("engine-start-location", ".");
+            madeCorrections = true;
+        }
+
+        return madeCorrections;
     }
 
     public Config() throws IOException {
@@ -149,6 +205,8 @@ public class Config {
         leelaz.put("max-game-thinking-time-seconds", 2);
         leelaz.put("print-comms", false);
         leelaz.put("analyze-update-interval-centisec", 10);
+        leelaz.put("engine-program", "./leelaz");
+        leelaz.put("engine-start-location", ".");
 
         config.put("leelaz", leelaz);
 
@@ -172,6 +230,7 @@ public class Config {
         ui.put("win-rate-always-black", false);
         ui.put("confirm-exit", false);
         ui.put("handicap-instead-of-winrate",false);
+        ui.put("board-size", 19);
 
         config.put("ui", ui);
         return config;

--- a/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
+++ b/src/main/java/wagner/stephanie/lizzie/analysis/Leelaz.java
@@ -76,7 +76,7 @@ public class Leelaz {
 
         // list of commands for the leelaz process
         List<String> commands = new ArrayList<>();
-        commands.add("./leelaz"); // windows, linux, mac all understand this
+        commands.add(config.optString("engine-program", "./leelaz")); // windows, linux, mac all understand this
         commands.add("-g");
         commands.add("-t");
         commands.add(""+config.getInt("threads"));
@@ -106,7 +106,7 @@ public class Leelaz {
 
         // run leelaz
         ProcessBuilder processBuilder = new ProcessBuilder(commands);
-        processBuilder.directory(new File("."));
+        processBuilder.directory(new File(config.optString("engine-start-location", ".")));
         processBuilder.redirectErrorStream(true);
         process = processBuilder.start();
 

--- a/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/wagner/stephanie/lizzie/gui/BoardRenderer.java
@@ -177,18 +177,7 @@ public class BoardRenderer {
             }
 
             // draw the star points
-            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-            int starPointRadius = (int) (STARPOINT_DIAMETER * boardLength) / 2;
-            final int NUM_STARPOINTS = 3;
-            final int STARPOINT_EDGE_OFFSET = 3;
-            final int STARPOINT_GRID_DISTANCE = 6;
-            for (int i = 0; i < NUM_STARPOINTS; i++) {
-                for (int j = 0; j < NUM_STARPOINTS; j++) {
-                    int centerX = x + scaledMargin + squareLength * (STARPOINT_EDGE_OFFSET + STARPOINT_GRID_DISTANCE * i);
-                    int centerY = y + scaledMargin + squareLength * (STARPOINT_EDGE_OFFSET + STARPOINT_GRID_DISTANCE * j);
-                    fillCircle(g, centerX, centerY, starPointRadius);
-                }
-            }
+            drawStarPoints(g);
 
             // draw coordinates if enabled
             if (showCoordinates()) {
@@ -199,8 +188,8 @@ public class BoardRenderer {
                     drawString(g, x + scaledMargin + squareLength * i, y - scaledMargin / 2 + boardLength, LizzieFrame.OpenSansRegularBase, "" + alphabet.charAt(i), stoneRadius * 4 / 5, stoneRadius);
                 }
                 for (int i = 0; i < Board.BOARD_SIZE; i++) {
-                    drawString(g, x + scaledMargin / 2, y + scaledMargin + squareLength * i, LizzieFrame.OpenSansRegularBase, "" + (19 - i), stoneRadius * 4 / 5, stoneRadius);
-                    drawString(g, x - scaledMargin / 2 + +boardLength, y + scaledMargin + squareLength * i, LizzieFrame.OpenSansRegularBase, "" + (19 - i), stoneRadius * 4 / 5, stoneRadius);
+                    drawString(g, x + scaledMargin / 2, y + scaledMargin + squareLength * i, LizzieFrame.OpenSansRegularBase, "" + (Board.BOARD_SIZE - i), stoneRadius * 4 / 5, stoneRadius);
+                    drawString(g, x - scaledMargin / 2 + +boardLength, y + scaledMargin + squareLength * i, LizzieFrame.OpenSansRegularBase, "" + (Board.BOARD_SIZE - i), stoneRadius * 4 / 5, stoneRadius);
                 }
             }
             cachedBackgroundImageHasCoordinatesEnabled = showCoordinates();
@@ -211,6 +200,76 @@ public class BoardRenderer {
         g0.drawImage(cachedBackgroundImage, 0, 0, null);
         cachedX = x;
         cachedY = y;
+    }
+
+    /**
+     * Draw the star points on the board, according to board size
+     *
+     * @param g graphics2d object to draw
+     */
+    private void drawStarPoints(Graphics2D g) {
+        if (Board.BOARD_SIZE == 9) {
+            drawStarPoints9x9(g);
+        } else if (Board.BOARD_SIZE == 13) {
+            drawStarPoints13x13(g);
+        } else {
+            drawStarPoints19x19(g);
+        }
+    }
+
+    private void drawStarPoints19x19(Graphics2D g) {
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        int starPointRadius = (int) (STARPOINT_DIAMETER * boardLength) / 2;
+        final int NUM_STARPOINTS = 3;
+        final int STARPOINT_EDGE_OFFSET = 3;
+        final int STARPOINT_GRID_DISTANCE = 6;
+        for (int i = 0; i < NUM_STARPOINTS; i++) {
+            for (int j = 0; j < NUM_STARPOINTS; j++) {
+                int centerX = x + scaledMargin + squareLength * (STARPOINT_EDGE_OFFSET + STARPOINT_GRID_DISTANCE * i);
+                int centerY = y + scaledMargin + squareLength * (STARPOINT_EDGE_OFFSET + STARPOINT_GRID_DISTANCE * j);
+                fillCircle(g, centerX, centerY, starPointRadius);
+            }
+        }
+    }
+
+    private void drawStarPoints13x13(Graphics2D g) {
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        int starPointRadius = (int) (STARPOINT_DIAMETER * boardLength) / 2;
+        final int NUM_STARPOINTS = 2;
+        final int STARPOINT_EDGE_OFFSET = 3;
+        final int STARPOINT_GRID_DISTANCE = 6;
+        for (int i = 0; i < NUM_STARPOINTS; i++) {
+            for (int j = 0; j < NUM_STARPOINTS; j++) {
+                int centerX = x + scaledMargin + squareLength * (STARPOINT_EDGE_OFFSET + STARPOINT_GRID_DISTANCE * i);
+                int centerY = y + scaledMargin + squareLength * (STARPOINT_EDGE_OFFSET + STARPOINT_GRID_DISTANCE * j);
+                fillCircle(g, centerX, centerY, starPointRadius);
+            }
+        }
+
+        // Draw center
+        int centerX = x + scaledMargin + squareLength * STARPOINT_GRID_DISTANCE;
+        int centerY = y + scaledMargin + squareLength * STARPOINT_GRID_DISTANCE;
+        fillCircle(g, centerX, centerY, starPointRadius);
+    }
+
+    private void drawStarPoints9x9(Graphics2D g) {
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        int starPointRadius = (int) (STARPOINT_DIAMETER * boardLength) / 2;
+        final int NUM_STARPOINTS = 2;
+        final int STARPOINT_EDGE_OFFSET = 2;
+        final int STARPOINT_GRID_DISTANCE = 4;
+        for (int i = 0; i < NUM_STARPOINTS; i++) {
+            for (int j = 0; j < NUM_STARPOINTS; j++) {
+                int centerX = x + scaledMargin + squareLength * (STARPOINT_EDGE_OFFSET + STARPOINT_GRID_DISTANCE * i);
+                int centerY = y + scaledMargin + squareLength * (STARPOINT_EDGE_OFFSET + STARPOINT_GRID_DISTANCE * j);
+                fillCircle(g, centerX, centerY, starPointRadius);
+            }
+        }
+
+        // Draw center
+        int centerX = x + scaledMargin + squareLength * STARPOINT_GRID_DISTANCE;
+        int centerY = y + scaledMargin + squareLength * STARPOINT_GRID_DISTANCE;
+        fillCircle(g, centerX, centerY, starPointRadius);
     }
 
     /**
@@ -343,6 +402,9 @@ public class BoardRenderer {
             for (int i = 0; i < bestMoves.size(); i++) {
                 MoveData move = bestMoves.get(i);
                 int[] coord = Board.convertNameToCoordinates(move.coordinate);
+                if (coord == null) {
+                    continue;
+                }
 
                 if (coord[0] == Lizzie.frame.mouseHoverCoordinate[0] && coord[1] == Lizzie.frame.mouseHoverCoordinate[1]) {
                     return move;
@@ -460,6 +522,10 @@ public class BoardRenderer {
                     // this is inefficient but it looks better with shadows
                     for (MoveData m : bestMoves) {
                         int[] coord = Board.convertNameToCoordinates(m.coordinate);
+                        // Handle passes
+                        if (coord == null) {
+                            continue;
+                        }
                         if (coord[0] == i && coord[1] == j) {
                             move = m;
                             break;

--- a/src/main/java/wagner/stephanie/lizzie/rules/Board.java
+++ b/src/main/java/wagner/stephanie/lizzie/rules/Board.java
@@ -12,7 +12,7 @@ import java.util.Queue;
 import java.util.List;
 
 public class Board implements LeelazListener {
-    public static final int BOARD_SIZE = 19;
+    public static final int BOARD_SIZE = Lizzie.config.config.getJSONObject("ui").optInt("board-size", 19);
     private final static String alphabet = "ABCDEFGHJKLMNOPQRST";
 
     private BoardHistoryList history;
@@ -65,6 +65,9 @@ public class Board implements LeelazListener {
      */
     public static int[] convertNameToCoordinates(String namedCoordinate) {
         namedCoordinate = namedCoordinate.trim();
+        if (namedCoordinate.equalsIgnoreCase("pass")) {
+            return null;
+        }
         // coordinates take the form C16 A19 Q5 K10 etc. I is not used.
         int x = alphabet.indexOf(namedCoordinate.charAt(0));
         int y = Integer.parseInt(namedCoordinate.substring(1)) - 1;


### PR DESCRIPTION
This PR addresses #152 . The issue only mentions 9x9 board support, but as far as I know, someone has started training 13x13 weights. Although the current weight is very weak, we can still expect a strong weight in a few months(I guess ?). So that I add 13x13 support too.

The code changes of small size boards are fairly simple. The key is the constant `Board.BOARD_SIZE`. There are a few places in class `BoardRenderer` that used hard-coded `19` as the board size. And all of the places have been modified to use the constant. Next, if we just change the board size and hard-code the number `9`, it should work. But it should be better to let the user configure the board size. So I added the config item `board-size` in `ui` category. To prevent some curious users spoiling the config item(e.g. set the size to 0, 10, or 1000), I added some code for checking and validating the settings. Finally, the star points of a 9x9 or 13x13 board are different from the standard 19x19 board. So I changed the drawing of star points to support 9x9 and 13x13.

It seems to be OK when we reach here. But I prefer to use a different file name for the 9x9 lz program(I use `leelaz9.exe`. ). So I added support for customizing leelaz programs. The config items `engine-program` and `engine-start-location` serve the purpose. Again, some checking codes are added to ensure correct configs.

There is no official 9x9 leelaz program, and we should build it from source if we want it. Just change the macro `BOARD_SIZE` in `config.h` and rebuild it. The weights have been uploaded to leelazero's site.

I've tested the change and it worked. But the stones on the board looked very huge (since a 9x9 board has enlarged to the same size as a 19x19 board). I think we can make some improvements on the display in the future, if needed.
