### PR TITLE
Fix issues on komi and handicap in SGF reader

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -283,8 +283,10 @@ public class Board implements LeelazListener {
          Stone[] stones = history.getStones();
          boolean blackToPlay = history.isBlacksTurn();
          Zobrist zobrist = history.getZobrist().clone();
+         BoardHistoryList oldHistory = history;
          history = new BoardHistoryList(new BoardData(stones, null, Stone.EMPTY, blackToPlay, zobrist,
                                                       0, new int[BOARD_SIZE * BOARD_SIZE], 0, 0, 0.0, 0));
+         history.setGameInfo(oldHistory.getGameInfo());
      }
 
     /**

--- a/src/main/java/featurecat/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardHistoryList.java
@@ -25,6 +25,10 @@ public class BoardHistoryList {
         return gameInfo;
     }
 
+    public void setGameInfo(GameInfo gameInfo) {
+        this.gameInfo = gameInfo;
+    }
+
     /**
      * Clear history.
      */

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -164,7 +164,11 @@ public class SGFParser {
                     } else if (tag.equals("PW")) {
                         whitePlayer = tagContent;
                     }  else if (tag.equals("KM")) {
-                        Lizzie.board.getHistory().getGameInfo().setKomi(Double.parseDouble(tagContent));
+                        try {
+                            Lizzie.board.getHistory().getGameInfo().setKomi(Double.parseDouble(tagContent));
+                        } catch (NumberFormatException e) {
+                            e.printStackTrace();
+                        }
                     }
                     break;
                 case ';':

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -165,6 +165,9 @@ public class SGFParser {
                         whitePlayer = tagContent;
                     }  else if (tag.equals("KM")) {
                         try {
+                            if (tagContent.trim().isEmpty()) {
+                                tagContent = "0.0";
+                            }
                             Lizzie.board.getHistory().getGameInfo().setKomi(Double.parseDouble(tagContent));
                         } catch (NumberFormatException e) {
                             e.printStackTrace();


### PR DESCRIPTION
These commits fix the following issues in SGF reader.

1. GameInfo was lost for handicapped SGF.
2. Reading failed for SGF with empty "KM[]".

example
http://gokifu.net/t2.php?s=7001484524613847
