### PR TITLE
Fix: suggestion appears on a existing stone after Ctrl-C

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardHistoryList.java
@@ -29,6 +29,13 @@ public class BoardHistoryList {
         this.gameInfo = gameInfo;
     }
 
+    public BoardHistoryList shallowCopy() {
+        BoardHistoryList copy = new BoardHistoryList(null);
+        copy.head = head;
+        copy.gameInfo = gameInfo;
+        return copy;
+    }
+
     /**
      * Clear history.
      */

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -217,7 +217,7 @@ public class SGFParser {
 
     private static void saveToStream(Board board, Writer writer) throws IOException {
         // collect game info
-        BoardHistoryList history = board.getHistory();
+        BoardHistoryList history = board.getHistory().shallowCopy();
         GameInfo gameInfo = history.getGameInfo();
         String playerBlack = gameInfo.getPlayerBlack();
         String playerWhite = gameInfo.getPlayerWhite();


### PR DESCRIPTION
1. Start lizzie
2. Hit "c" key (coordinates on)
4. Click D17 (black)
5. Hit UP ARROW key (undo)
6. Hit Ctrl-C (save to clipboard)

Then suggestion appears on the existing stone at D17.  This happens
because saveToStream in SGFParser.java moves head of history as a side
effect without telling it to leelaz.

Though this is not a serious issue by itself, it is problematic for
developing an autosave feature (#140, #263).
