### PR TITLE
Fix too slow "End", "Ctrl-V", etc. by omitting unnecessary lz-analyze

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -33,6 +33,7 @@ public class Leelaz {
     private long maxAnalyzeTimeMillis;//, maxThinkingTimeMillis;
     private int cmdNumber;
     private int currentCmdNum;
+    private ArrayDeque<String> cmdQueue;
 
     private Process process;
 
@@ -71,7 +72,8 @@ public class Leelaz {
         isPondering = false;
         startPonderTime = System.currentTimeMillis();
         cmdNumber = 1;
-        currentCmdNum = -1;
+        currentCmdNum = 0;
+        cmdQueue = new ArrayDeque<>();
 
         JSONObject config = Lizzie.config.config.getJSONObject("leelaz");
 
@@ -188,7 +190,7 @@ public class Leelaz {
                 // End of response
             } else if (line.startsWith("info")) {
                 isLoaded = true;
-                if (currentCmdNum == cmdNumber - 1) {
+                if (isResponseUpToDate()) {
                     // This should not be stale data when the command number match
                     parseInfo(line.substring(5));
                     notifyBestMoveListeners();
@@ -205,14 +207,16 @@ public class Leelaz {
                 }
                 isThinking = false;
 
-            } else if (Lizzie.frame != null && line.startsWith("=")) {
+            } else if (Lizzie.frame != null && (line.startsWith("=") || line.startsWith("?"))) {
                 if (printCommunication) {
                     System.out.print(line);
                 }
                 String[] params = line.trim().split(" ");
                 currentCmdNum = Integer.parseInt(params[0].substring(1).trim());
 
-                if (params.length == 1) return;
+                trySendCommandFromQueue();
+
+                if (line.startsWith("?") || params.length == 1) return;
 
 
                 if (isSettingHandicap) {
@@ -284,11 +288,43 @@ public class Leelaz {
     }
 
     /**
-     * Sends a command for leelaz to execute
+     * Sends a command to command queue for leelaz to execute
      *
      * @param command a GTP command containing no newline characters
      */
     public void sendCommand(String command) {
+        synchronized(cmdQueue) {
+            String lastCommand = cmdQueue.peekLast();
+            // For efficiency, delete unnecessary "lz-analyze" that will be stopped immediately
+            if (lastCommand != null && lastCommand.startsWith("lz-analyze")) {
+                cmdQueue.removeLast();
+            }
+            cmdQueue.addLast(command);
+            trySendCommandFromQueue();
+        }
+    }
+
+    /**
+     * Sends a command from command queue for leelaz to execute if it is ready
+     */
+    private void trySendCommandFromQueue() {
+        if (!isResponseUpToDate()) {
+            return;  // leelaz is not ready yet
+        }
+        synchronized(cmdQueue) {
+            String command = cmdQueue.pollFirst();
+            if (command != null) {
+                sendCommandToLeelaz(command);
+            }
+        }
+    }
+
+    /**
+     * Sends a command for leelaz to execute
+     *
+     * @param command a GTP command containing no newline characters
+     */
+    private void sendCommandToLeelaz(String command) {
         if (command.startsWith("fixed_handicap"))
             isSettingHandicap = true;
         command = cmdNumber + " " + command;
@@ -302,6 +338,14 @@ public class Leelaz {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    /**
+     * Check whether leelaz is responding to the last command
+     */
+    private boolean isResponseUpToDate() {
+        // Use >= instead of == for avoiding hang-up, though it cannot happen
+        return currentCmdNum >= cmdNumber - 1;
     }
 
     /**


### PR DESCRIPTION
"Ctrl-V" takes several minutes on my machine.
It is caused by "lz-analyze" after every "play ..." and "undo".
You may not notice this issue if your machine is fast.

The first patch introduces a command queue and defers sending commands
until leelaz responds to the previous command.
Unnecessary "lz-analyze", that will be stopped immediately by the next command,
is removed from the queue before sending it to leelaz.

I also add the second patch for preventing possible hang-up in unexpected cases
that cannot happen theoretically.

    $ git log --oneline | head -n 1
    1912f4a Merge pull request #272 from kaorahi/komi_sgf
