### PR TITLE
Increase/decrease alpha value by ctrl-shift-pgup/pgdown

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -32,7 +32,7 @@ public class Config {
     private String configFilename = "config.txt";
     private String persistFilename = "persist";
 
-    private JSONObject loadAndMergeConfig(JSONObject defaultCfg, String fileName) throws IOException {
+    private JSONObject loadAndMergeConfig(JSONObject defaultCfg, String fileName, boolean needValidation) throws IOException {
         File file = new File(fileName);
         if (!file.canRead()) {
             System.err.printf("Creating config file %s\n", fileName);
@@ -59,7 +59,7 @@ public class Config {
         fp.close();
 
         // Validate and correct settings
-        if (validateAndCorrectSettings(mergedcfg)) {
+        if (needValidation && validateAndCorrectSettings(mergedcfg)) {
             modified = true;
         }
 
@@ -82,8 +82,7 @@ public class Config {
      * @return if any correction has been made.
      */
     private boolean validateAndCorrectSettings(JSONObject config) {
-        // We don't care persisted settings. They are managed automatically.
-        if (config == null || !config.has("ui")) {
+        if (config == null) {
             return false;
         }
 
@@ -125,9 +124,9 @@ public class Config {
         JSONObject persistConfig = createPersistConfig();
 
         // Main properties
-        this.config = loadAndMergeConfig(defaultConfig, configFilename);
+        this.config = loadAndMergeConfig(defaultConfig, configFilename, true);
         // Persisted properties
-        this.persisted = loadAndMergeConfig(persistConfig, persistFilename);
+        this.persisted = loadAndMergeConfig(persistConfig, persistFilename, false);
 
         leelazConfig = config.getJSONObject("leelaz");
         uiConfig = config.getJSONObject("ui");
@@ -274,12 +273,16 @@ public class Config {
         config.put("filesystem", filesys);
 
         // About User Interface display
-        //JSONObject ui = new JSONObject();
+        JSONObject ui = new JSONObject();
 
         //ui.put("window-height", 657);
         //ui.put("window-width", 687);
+        //ui.put("max-alpha", 240);
 
-        //config.put("ui", ui);
+        // Avoid the key "ui" because it was used to distinguish "config" and "persist"
+        // in old version of validateAndCorrectSettings().
+        // If we use "ui" here, we will have trouble to run old lizzie.
+        config.put("ui-persist", ui);
         return config;
     }
 

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.gui;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.analysis.Branch;
@@ -30,7 +31,7 @@ public class BoardRenderer {
     private int x, y;
     private int boardLength;
 
-    private JSONObject uiConfig;
+    private JSONObject uiConfig, uiPersist;
 
     private int scaledMargin, availableLength, squareLength, stoneRadius;
     private Branch branch;
@@ -69,6 +70,10 @@ public class BoardRenderer {
         if (theme == null) {
             theme = new DefaultTheme();
         }
+        uiPersist = Lizzie.config.persisted.getJSONObject("ui-persist");
+        try {
+            maxAlpha = uiPersist.getInt("max-alpha");
+        } catch (JSONException e) {}
         this.isMainBoard = isMainBoard;
     }
 
@@ -1007,5 +1012,6 @@ public class BoardRenderer {
 
     public void increaseMaxAlpha(int k) {
         maxAlpha = Math.min(maxAlpha + k, 255);
+        uiPersist.put("max-alpha", maxAlpha);
     }
 }

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -61,6 +61,8 @@ public class BoardRenderer {
     private boolean showingBranch = false;
     private boolean isMainBoard = false;
 
+    private int maxAlpha = 240;
+
     public BoardRenderer(boolean isMainBoard) {
         uiConfig = Lizzie.config.config.getJSONObject("ui");
         theme = ITheme.loadTheme(uiConfig.getString("theme"));
@@ -497,7 +499,7 @@ public class BoardRenderer {
 
         final int MIN_ALPHA = 32;
         final int MIN_ALPHA_TO_DISPLAY_TEXT = 64;
-        final int MAX_ALPHA = 240;
+        final int MAX_ALPHA = maxAlpha = Math.max(maxAlpha, MIN_ALPHA_TO_DISPLAY_TEXT);
         final double HUE_SCALING_FACTOR = 3.0;
         final double ALPHA_SCALING_FACTOR = 5.0;
         final float GREEN_HUE = Color.RGBtoHSB(0,1,0,null)[0];
@@ -1001,5 +1003,9 @@ public class BoardRenderer {
 
     private boolean showCoordinates() {
         return isMainBoard && Lizzie.frame.showCoordinates;
+    }
+
+    public void increaseMaxAlpha(int k) {
+        maxAlpha = Math.min(maxAlpha + k, 255);
     }
 }

--- a/src/main/java/featurecat/lizzie/gui/Input.java
+++ b/src/main/java/featurecat/lizzie/gui/Input.java
@@ -197,7 +197,11 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
                 
             case VK_PAGE_DOWN:
-                redo(10);
+                if (controlIsPressed(e) && e.isShiftDown()) {
+                    Lizzie.frame.increaseMaxAlpha(-5);
+                } else {
+                    redo(10);
+                }
                 break;
 
             case VK_DOWN:
@@ -245,7 +249,11 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 break;
                 
             case VK_PAGE_UP:
-                undo(10);
+                if (controlIsPressed(e) && e.isShiftDown()) {
+                    Lizzie.frame.increaseMaxAlpha(5);
+                } else {
+                    undo(10);
+                }
                 break;
 
             case VK_I:

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -896,4 +896,8 @@ public class LizzieFrame extends JFrame {
             e.printStackTrace();
         }
     }
+
+    public void increaseMaxAlpha(int k) {
+        boardRenderer.increaseMaxAlpha(k);
+    }
 }


### PR DESCRIPTION
I prefer modest suggestions so that I can imagine the current board
situation without holding "z" key down.  I assigned minor keys
(ctrl-shift-pgup/pgdown) to modify the opacity of suggestions since
we will not use them frequently.
