### PR TITLE
Fix "Did not find network/weights"

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -83,7 +83,7 @@ public class Leelaz {
             updateToLatestNetwork();
         }
 
-        String startfolder = Config.getBestDefaultLeelazPath(); // todo make this a little more obvious/less bug-prone
+        String startfolder = new File(Config.getBestDefaultLeelazPath()).getParent(); // todo make this a little more obvious/less bug-prone
 
         // Check if network file is present
         File wf = new File(startfolder + '/' + config.getString("network-file"));


### PR DESCRIPTION
I get the below alert dialog at startup without this patch.

    Did not find network/weights.
    Update config.txt (network-file) or download from Leela Zero homepage

The value of the variable startfolder should be ".". But I get "./leelaz".
