### PR TITLE
Add autosave and resume

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -258,6 +258,7 @@ public class Config {
         ui.put("win-rate-always-black", false);
         ui.put("confirm-exit", false);
         ui.put("resume-previous-game", false);
+        ui.put("autosave-interval-seconds", -1);
         ui.put("handicap-instead-of-winrate",false);
         ui.put("board-size", 19);
         ui.put("window-size", new JSONArray("[1024, 768]"));

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -257,6 +257,7 @@ public class Config {
         ui.put("large-subboard", false);
         ui.put("win-rate-always-black", false);
         ui.put("confirm-exit", false);
+        ui.put("resume-previous-game", false);
         ui.put("handicap-instead-of-winrate",false);
         ui.put("board-size", 19);
         ui.put("window-size", new JSONArray("[1024, 768]"));

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -4,6 +4,7 @@ import org.json.JSONException;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.plugin.PluginManager;
 import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.SGFParser;
 import featurecat.lizzie.gui.LizzieFrame;
 import org.json.JSONObject;
 
@@ -57,6 +58,9 @@ public class Lizzie {
                 if(config.handicapInsteadOfWinrate) {
                 	leelaz.estimatePassWinrate();
                 }
+                if (config.config.getJSONObject("ui").getBoolean("resume-previous-game")) {
+                    board.resumePreviousGame();
+                }
                 leelaz.togglePonder();
             } catch (IOException e) {
                 e.printStackTrace();
@@ -73,6 +77,9 @@ public class Lizzie {
             if (ret == JOptionPane.OK_OPTION) {
                 LizzieFrame.saveSgf();
             }
+        }
+        if (board != null) {
+            board.autosaveToMemory();
         }
 
         try {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -92,6 +92,8 @@ public class LizzieFrame extends JFrame {
     // Get the font name in current system locale
     private String systemDefaultFontName = new JLabel().getFont().getFontName();
 
+    private long lastAutosaveTime = System.currentTimeMillis();
+
     static {
         // load fonts
         try {
@@ -252,6 +254,7 @@ public class LizzieFrame extends JFrame {
      * @param g0 not used
      */
     public void paint(Graphics g0) {
+        autosaveMaybe();
         if (bs == null)
             return;
 
@@ -832,6 +835,15 @@ public class LizzieFrame extends JFrame {
             if (Lizzie.board.goToMoveNumberWithinBranch(moveNumber)) {
                 repaint();
             }
+        }
+    }
+
+    private void autosaveMaybe() {
+        int interval = Lizzie.config.config.getJSONObject("ui").getInt("autosave-interval-seconds") * 1000;
+        long currentTime = System.currentTimeMillis();
+        if (interval > 0 && currentTime - lastAutosaveTime >= interval) {
+            Lizzie.board.autosave();
+            lastAutosaveTime = currentTime;
         }
     }
 

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -4,12 +4,15 @@ import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.analysis.LeelazListener;
 import featurecat.lizzie.analysis.MoveData;
+import featurecat.lizzie.rules.SGFParser;
 
+import java.io.IOException;
 import javax.swing.*;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Queue;
 import java.util.List;
+import org.json.JSONException;
 
 public class Board implements LeelazListener {
     public static final int BOARD_SIZE = Lizzie.config.config.getJSONObject("ui").optInt("board-size", 19);
@@ -1050,5 +1053,25 @@ public class Board implements LeelazListener {
                 }
             }
         }
+    }
+
+    public void autosave() {
+        autosaveToMemory();
+        try {
+            Lizzie.config.persist();
+        } catch (IOException err) {}
+    }
+
+    public void autosaveToMemory() {
+        try {
+            Lizzie.config.persisted.put("autosave", SGFParser.saveToString());
+        } catch (IOException err) {}
+    }
+
+    public void resumePreviousGame() {
+        try {
+            SGFParser.loadFromString(Lizzie.config.persisted.getString("autosave"));
+            while (nextMove()) ;
+        } catch (JSONException err) {}
     }
 }

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1056,16 +1056,24 @@ public class Board implements LeelazListener {
     }
 
     public void autosave() {
-        autosaveToMemory();
-        try {
-            Lizzie.config.persist();
-        } catch (IOException err) {}
+        if (autosaveToMemory()) {
+            try {
+                Lizzie.config.persist();
+            } catch (IOException err) {}
+        }
     }
 
-    public void autosaveToMemory() {
+    public boolean autosaveToMemory() {
         try {
-            Lizzie.config.persisted.put("autosave", SGFParser.saveToString());
-        } catch (IOException err) {}
+            String sgf = SGFParser.saveToString();
+            if (sgf.equals(Lizzie.config.persisted.getString("autosave"))) {
+                return false;
+            }
+            Lizzie.config.persisted.put("autosave", sgf);
+        } catch (Exception err) { // IOException or JSONException
+            return false;
+        }
+        return true;
     }
 
     public void resumePreviousGame() {


### PR DESCRIPTION
The first commit saves SGF of the main branch into "persist" when
lizzie is shut down.  It is resumed at the next time if
"resume-previous-game" is true in config.txt.

The second commit calls autosave periodically in case of sudden crash,
though I rarely experienced it.  This periodical autosave is turned on
if "autosave-interval-seconds" is positive in config.txt.

(ref. #140, #263)
