### PR TITLE
Fix #296 (MultiGo SGF detection)

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -72,7 +72,7 @@ public class SGFParser {
         StringBuilder tagContentBuilder = new StringBuilder();
         // MultiGo 's branch: (Main Branch (Main Branch) (Branch) )
         // Other 's branch: (Main Branch (Branch) Main Branch)
-        if (value.matches("(?m)(?s).*\\)\\s*\\)")) {
+        if (value.matches("(?s).*\\)\\s*\\)")) {
             isMultiGo = true;
         }
 

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -72,7 +72,7 @@ public class SGFParser {
         StringBuilder tagContentBuilder = new StringBuilder();
         // MultiGo 's branch: (Main Branch (Main Branch) (Branch) )
         // Other 's branch: (Main Branch (Branch) Main Branch)
-        if (value.charAt(value.length() - 2) == ')') {
+        if (value.matches("(?m)(?s).*\\)\\s*\\)")) {
             isMultiGo = true;
         }
 


### PR DESCRIPTION
This patch allows whitespace characters between the last two ")"s in the detection of MultiGo SGF.