### PR TITLE
Configurable threshold for displaying move statistics.

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -272,6 +272,7 @@ public class Config {
         ui.put("window-size", new JSONArray("[1024, 768]"));
         ui.put("window-maximized", false);
         ui.put("show-dynamic-komi", true);
+        ui.put("min-playout-ratio-for-stats", 0.0);
 
         config.put("ui", ui);
         return config;

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -503,12 +503,10 @@ public class BoardRenderer {
             return;
 
         final int MIN_ALPHA = 32;
-        final int MIN_ALPHA_TO_DISPLAY_TEXT = 64;
-        final int MAX_ALPHA = maxAlpha = Math.max(maxAlpha, MIN_ALPHA_TO_DISPLAY_TEXT);
         final double HUE_SCALING_FACTOR = 3.0;
         final double ALPHA_SCALING_FACTOR = 5.0;
-        final float GREEN_HUE = Color.RGBtoHSB(0,1,0,null)[0];
-        final float CYAN_HUE = Color.RGBtoHSB(0,1,1,null)[0];
+        final float GREEN_HUE = Color.RGBtoHSB(0, 1, 0, null)[0];
+        final float CYAN_HUE = Color.RGBtoHSB(0, 1, 1, null)[0];
 
         if (!bestMoves.isEmpty()) {
 
@@ -558,7 +556,7 @@ public class BoardRenderer {
                     float hue = isBestMove ? CYAN_HUE : (float) (-GREEN_HUE * Math.max(0, Math.log(percentPlayouts) / HUE_SCALING_FACTOR + 1));
                     float saturation = 0.75f; //saturation
                     float brightness = 0.85f; //brightness
-                    int alpha = (int) (MIN_ALPHA + (MAX_ALPHA - MIN_ALPHA) * Math.max(0, Math.log(percentPlayouts) /
+                    int alpha = (int) (MIN_ALPHA + (maxAlpha - MIN_ALPHA) * Math.max(0, Math.log(percentPlayouts) /
                             ALPHA_SCALING_FACTOR + 1));
 //                    if (uiConfig.getBoolean("shadows-enabled"))
 //                        alpha = 255;
@@ -586,7 +584,8 @@ public class BoardRenderer {
                     }
 
 
-                    if (branch == null && (alpha >= MIN_ALPHA_TO_DISPLAY_TEXT || hasMaxWinrate) || (Lizzie.frame.mouseHoverCoordinate != null && coordinates[0] == Lizzie.frame.mouseHoverCoordinate[0] && coordinates[1] == Lizzie.frame.mouseHoverCoordinate[1])) {
+                    if ((branch == null && (hasMaxWinrate || percentPlayouts >= uiConfig.getDouble("min-playout-ratio-for-stats"))) ||
+                        (Lizzie.frame.mouseHoverCoordinate != null && coordinates[0] == Lizzie.frame.mouseHoverCoordinate[0] && coordinates[1] == Lizzie.frame.mouseHoverCoordinate[1])) {
                         double roundedWinrate = Math.round(move.winrate * 10) / 10.0;
                         if (uiConfig.getBoolean("win-rate-always-black") && !Lizzie.board.getData().blackToPlay) {
                            roundedWinrate = 100.0 - roundedWinrate;


### PR DESCRIPTION
As I personally don't find it annoying to see as many statistics on the board as possible, I figured it would make sense to have a configurable display threshold setting.