### PR TITLE
 Fix location checks, and use engine-start-location directly

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -105,15 +105,7 @@ public class Config {
 
         // Check engine configs
         JSONObject leelaz = config.getJSONObject("leelaz");
-        // Check if the engine program exists.
-        String enginePath = leelaz.optString("engine-program", getBestDefaultLeelazPath());
-        if (!Files.exists(Paths.get(enginePath)) && !Files.exists(Paths.get(enginePath + ".exe" /* For windows */))) {
-            // FIXME: I don't know how to handle it properly.. Possibly showing a warning dialog may be a good idea?
-            leelaz.put("engine-program", "./leelaz");
-            madeCorrections = true;
-        }
-
-        // Similar checks for startup directory. It should exist and should be a directory.
+        // Checks for startup directory. It should exist and should be a directory.
         String engineStartLocation = getBestDefaultLeelazPath();
         if (!(Files.exists(Paths.get(engineStartLocation)) && Files.isDirectory(Paths.get(engineStartLocation)))) {
             leelaz.put("engine-start-location", ".");

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -28,28 +28,9 @@ public class Lizzie {
      */
     public static void main(String[] args) throws IOException, JSONException, ClassNotFoundException, UnsupportedLookAndFeelException, InstantiationException, IllegalAccessException, InterruptedException {
         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-
         config = new Config();
-
-        // Check that user has installed leela zero
-        JSONObject leelazconfig = Lizzie.config.config.getJSONObject("leelaz");
-        ResourceBundle resourceBundle = ResourceBundle.getBundle("l10n.DisplayStrings");
-        String startfolder = leelazconfig.optString("engine-start-location", ".");
-
-        // Check if engine is present
-        File lef = new File(startfolder + '/' + "leelaz");
-        if (!lef.exists()) {
-            File leexe = new File(startfolder + '/' + "leelaz.exe");
-            if (!leexe.exists()) {
-                JOptionPane.showMessageDialog(null, resourceBundle.getString("LizzieFrame.display.leelaz-missing"), "Lizzie - Error!", JOptionPane.ERROR_MESSAGE);
-                return;
-            }
-        }
-
         PluginManager.loadPlugins();
-
         board = new Board();
-
         frame = new LizzieFrame();
 
         new Thread( () -> {
@@ -66,10 +47,9 @@ public class Lizzie {
                 leelaz.togglePonder();
             } catch (IOException e) {
                 e.printStackTrace();
+                System.exit(-1);
             }
         }).start();
-
-
     }
 
     public static void shutdown() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -87,25 +87,31 @@ public class Leelaz {
             updateToLatestNetwork();
         }
 
-        String startfolder = new File(Config.getBestDefaultLeelazPath()).getParent(); // todo make this a little more obvious/less bug-prone
-
-        // Check if network file is present
-        File wf = new File(startfolder + '/' + config.getString("network-file"));
-        if (!wf.exists()) {
-            JOptionPane.showMessageDialog(null, resourceBundle.getString("LizzieFrame.display.network-missing"));
-        }
-
-
-        // command string for starting the engine
+        File startfolder = new File(config.optString("engine-start-location", "."));
         String engineCommand = config.getString("engine-command");
+        String networkFile = config.getString("network-file");
         // substitute in the weights file
-        engineCommand = engineCommand.replaceAll("%network-file", config.getString("network-file"));
+        engineCommand = engineCommand.replaceAll("%network-file", networkFile);
         // create this as a list which gets passed into the processbuilder
         List<String> commands = Arrays.asList(engineCommand.split(" "));
 
+        // Check if engine is present
+        File lef = startfolder.toPath().resolve(new File(commands.get(0)).toPath()).toFile();
+        if (!lef.exists()) {
+            JOptionPane.showMessageDialog(null, resourceBundle.getString("LizzieFrame.display.leelaz-missing"), "Lizzie - Error!", JOptionPane.ERROR_MESSAGE);
+            throw new IOException("engine not present");
+        }
+
+         // Check if network file is present
+        File wf = startfolder.toPath().resolve(new File(networkFile).toPath()).toFile();
+        if (!wf.exists()) {
+            JOptionPane.showMessageDialog(null, resourceBundle.getString("LizzieFrame.display.network-missing"));
+            throw new IOException("network-file not present");
+        }
+
         // run leelaz
         ProcessBuilder processBuilder = new ProcessBuilder(commands);
-        processBuilder.directory(new File(startfolder));
+        processBuilder.directory(startfolder);
         processBuilder.redirectErrorStream(true);
         process = processBuilder.start();
 

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -51,5 +51,5 @@ LizzieFrame.display.off=off
 LizzieFrame.display.loading=Leela Zero is loading...
 LizzieFrame.display.download-latest-network-prompt=Download the latest network file? This may take some time.
 LizzieFrame.display.leelaz-missing=Did not find Leela Zero, update config.txt or download from Leela Zero homepage
-LizzieFrame.display.network-missing=Did not find network/weights.\nUpdate config.txt (network-file) or download from Leela Zero homepage
+LizzieFrame.display.network-missing=Did not find network weights.\nUpdate config.txt (network-file) or download from Leela Zero homepage
 LizzieFrame.display.dynamic-komi=dyn. komi:

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -39,5 +39,5 @@ LizzieFrame.display.off=\u6682\u505C
 LizzieFrame.display.loading=Leela Zero\u6B63\u5728\u8F7D\u5165\u4E2D...
 LizzieFrame.display.download-latest-network-prompt=Download the latest network file? This may take some time.
 LizzieFrame.display.leelaz-missing=Did not find Leela Zero, update config.txt or download from Leela Zero homepage
-LizzieFrame.display.network-missing=Did not find network/weights.\nUpdate config.txt (network-file) or download from Leela Zero homepage
+LizzieFrame.display.network-missing=Did not find network weights.\nUpdate config.txt (network-file) or download from Leela Zero homepage
 LizzieFrame.display.dynamic-komi=dyn. komi:


### PR DESCRIPTION
Fixes #323 

Don't pointlessly recalculate paths, just take them from the config directly since they've already been calculated by then.

Drop `engine-program` since it's not being used, just take the first element of the split string `engine-command` like we already do for `ProcessBuilder`.