### PR TITLE
Fix #362: show best moves after --visit exhaustion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <compilerArgs>
+                      <arg>-Xlint:all</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>
@@ -52,6 +55,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <!-- Required to get the test failure reports in stdout -->
+                    <useFile>false</useFile>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -63,5 +75,12 @@
             <version>20180130</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -164,15 +164,11 @@ public class Leelaz {
     }
 
     private void parseInfo(String line) {
-
         bestMoves = new ArrayList<>();
         String[] variations = line.split(" info ");
         for (String var : variations) {
             bestMoves.add(MoveData.fromInfo(var));
         }
-        // Not actually necessary to sort with current version of LZ (0.15)
-        // but not guaranteed to be ordered in the future
-        Collections.sort(bestMoves);
     }
 
     /**

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -21,7 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * an interface with leelaz.exe go engine. Can be adapted for GTP, but is specifically designed for GCP's Leela Zero.
+ * An interface with leelaz go engine. Can be adapted for GTP, but is specifically designed for GCP's Leela Zero.
  * leelaz is modified to output information as it ponders
  * see www.github.com/gcp/leela-zero
  */
@@ -168,7 +168,7 @@ public class Leelaz {
         bestMoves = new ArrayList<>();
         String[] variations = line.split(" info ");
         for (String var : variations) {
-            bestMoves.add(new MoveData(var));
+            bestMoves.add(MoveData.fromInfo(var));
         }
         // Not actually necessary to sort with current version of LZ (0.15)
         // but not guaranteed to be ordered in the future
@@ -182,25 +182,21 @@ public class Leelaz {
      */
     private void parseLine(String line) {
         synchronized (this) {
-            if (line.startsWith("komi="))
-            {
+            if (line.startsWith("komi=")) {
                 try {
                     dynamicKomi = Float.parseFloat(line.substring("komi=".length()).trim());
                 }
                 catch (NumberFormatException nfe) {
                     dynamicKomi = Float.NaN;
                 }
-            }
-            else if (line.startsWith("opp_komi="))
-            {
+            } else if (line.startsWith("opp_komi=")) {
                 try {
                     dynamicOppKomi = Float.parseFloat(line.substring("opp_komi=".length()).trim());
                 }
                 catch (NumberFormatException nfe) {
                     dynamicOppKomi = Float.NaN;
                 }
-            }
-            else if (line.equals("\n")) {
+            } else if (line.equals("\n")) {
                 // End of response
             } else if (line.startsWith("info")) {
                 isLoaded = true;
@@ -268,7 +264,7 @@ public class Leelaz {
         if (line.length() > 0 && Character.isLetter(line.charAt(0)) && !line.startsWith("pass")) {
             if (!(Lizzie.frame != null && Lizzie.frame.isPlayingAgainstLeelaz && Lizzie.frame.playerIsBlack != Lizzie.board.getData().blackToPlay)) {
                 try {
-                    bestMovesTemp.add(new MoveData(line));
+                    bestMovesTemp.add(MoveData.fromInfo(line));
                 } catch (ArrayIndexOutOfBoundsException e) {
                     // this is very rare but is possible. ignore
                 }
@@ -415,7 +411,7 @@ public class Leelaz {
     }
 
     /**
-     * this initializes leelaz's pondering mode at its current position
+     * This initializes leelaz's pondering mode at its current position
      */
     private void ponder() {
         isPondering = true;

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -206,6 +206,13 @@ public class Leelaz {
                         togglePonder();
                     }
                 }
+            } else if (line.contains(" -> ")) {
+                isLoaded = true;
+                if (isResponseUpToDate()) {
+                    bestMoves.add(MoveData.fromSummary(line));
+                    if (Lizzie.frame != null)
+                        Lizzie.frame.repaint();
+                }
             } else if (line.startsWith("play")) {
                 // In lz-genmove_analyze
                 if (Lizzie.frame.isPlayingAgainstLeelaz) {

--- a/src/main/java/featurecat/lizzie/analysis/MoveData.java
+++ b/src/main/java/featurecat/lizzie/analysis/MoveData.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * holds the data from Leelaz's pondering mode
+ * Holds the data from Leelaz's pondering mode
  */
 public class MoveData implements Comparable<MoveData> {
     public String coordinate;
@@ -14,41 +14,56 @@ public class MoveData implements Comparable<MoveData> {
     public int order;
     public List<String> variation;
 
+    private MoveData() {}
+
+    public int compareTo(MoveData b) {
+        return order - b.order;
+    }
+
     /**
-     * Parses a leelaz ponder output line
+     * Parses a leelaz ponder output line. For example:
+     *
+     * info move R5 visits 38 winrate 5404 order 0 pv R5 Q5 R6 S4 Q10 C3 D3 C4 C6 C5 D5
+     *
      * @param line line of ponder output
      */
-    public MoveData(String line) throws ArrayIndexOutOfBoundsException {
+    public static MoveData fromInfo(String line) throws ArrayIndexOutOfBoundsException {
+        MoveData result = new MoveData();
         String[] data = line.trim().split(" ");
 
         // Todo: Proper tag parsing in case gtp protocol is extended(?)/changed
-
         for (int i=0; i<data.length; i++) {
             String key = data[i];
             if (key.equals("pv")) {
-                //read variation to the end of line
-                variation = new ArrayList<>(Arrays.asList(data));
-                variation = variation.subList(i+1, data.length);
+                // Read variation to the end of line
+                result.variation = new ArrayList<>(Arrays.asList(data));
+                result.variation = result.variation.subList(i + 1, data.length);
                 break;
             } else {
                 String value = data[++i];
                 if (key.equals("move")) {
-                    coordinate = value;
+                    result.coordinate = value;
                 }
                 if (key.equals("visits")) {
-                    playouts =  Integer.parseInt(value);
+                    result.playouts = Integer.parseInt(value);
                 }
                 if (key.equals("winrate")) {
-                    winrate = Integer.parseInt(value)/100.0;
-                }
-                if (key.equals("order")) {
-                    order = Integer.parseInt(value);
+                    result.winrate = Integer.parseInt(value) / 100.0;
                 }
             }
         }
+
+        return result;
     }
 
-    public int compareTo(MoveData b) {
-        return order - b.order;
+    /**
+     * Parses a leelaz summary output line. For example:
+     *
+     * P16 ->       4 (V: 50.94%) (N:  5.79%) PV: P16 N18 R5 Q5
+     *
+     * @param line line of summary output
+     */
+    public static MoveData fromSummary(String summary) {
+      return new MoveData(); // TODO
     }
 }

--- a/src/main/java/featurecat/lizzie/analysis/MoveData.java
+++ b/src/main/java/featurecat/lizzie/analysis/MoveData.java
@@ -3,6 +3,8 @@ package featurecat.lizzie.analysis;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Holds the data from Leelaz's pondering mode
@@ -58,6 +60,19 @@ public class MoveData {
      * @param line line of summary output
      */
     public static MoveData fromSummary(String summary) {
-      return new MoveData(); // TODO
+        Matcher match = summaryPattern.matcher(summary.trim());
+        if (!match.matches()) {
+            throw new IllegalArgumentException("Unexpected summary format: " + summary);
+        } else {
+            MoveData result = new MoveData();
+            result.coordinate = match.group(1);
+            result.playouts   = Integer.parseInt(match.group(2));
+            result.winrate    = Double.parseDouble(match.group(3));
+            result.variation  = Arrays.asList(match.group(4).split(" "));
+            return result;
+        }
     }
+
+    private static Pattern summaryPattern = Pattern.compile(
+      "^ *(\\w\\d*) -> *(\\d+) \\(V: ([^%)]+)%\\) \\([^\\)]+\\) PV: (.+).*$");
 }

--- a/src/main/java/featurecat/lizzie/analysis/MoveData.java
+++ b/src/main/java/featurecat/lizzie/analysis/MoveData.java
@@ -7,18 +7,13 @@ import java.util.List;
 /**
  * Holds the data from Leelaz's pondering mode
  */
-public class MoveData implements Comparable<MoveData> {
+public class MoveData {
     public String coordinate;
     public int playouts;
     public double winrate;
-    public int order;
     public List<String> variation;
 
     private MoveData() {}
-
-    public int compareTo(MoveData b) {
-        return order - b.order;
-    }
 
     /**
      * Parses a leelaz ponder output line. For example:
@@ -52,7 +47,6 @@ public class MoveData implements Comparable<MoveData> {
                 }
             }
         }
-
         return result;
     }
 

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -745,6 +745,7 @@ public class Board implements LeelazListener {
             if (inScoreMode()) setScoreMode(false);
             // Update win rate statistics
             Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
+
             if (stats.totalPlayouts >= history.getData().playouts) {
                 history.getData().winrate = stats.maxWinrate;
                 history.getData().playouts = stats.totalPlayouts;

--- a/src/test/java/featurecat/lizzie/analysis/MoveDataTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/MoveDataTest.java
@@ -1,0 +1,23 @@
+package featurecat.lizzie.analysis;
+
+import org.junit.Test;
+import java.util.List;
+import java.util.Arrays;
+import static org.junit.Assert.assertEquals;
+
+public class MoveDataTest {
+  @Test public void testFromInfoLine() {
+    String info = "move R5 visits 38 winrate 5404 order 0 pv R5 Q5 R6 S4 Q10 C3 D3 C4 C6 C5 D5";
+    MoveData moveData = MoveData.fromInfo(info);
+
+    assertEquals(moveData.coordinate, "R5");
+    assertEquals(moveData.playouts, 38);
+    assertEquals(moveData.winrate, 54.04, 0.01);
+    assertEquals(moveData.order, 0);
+
+    List<String> expected = Arrays.asList(
+      "R5", "Q5", "R6", "S4", "Q10", "C3", "D3", "C4", "C6", "C5", "D5");
+
+    assertEquals(moveData.variation, expected);
+  }
+}

--- a/src/test/java/featurecat/lizzie/analysis/MoveDataTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/MoveDataTest.java
@@ -13,11 +13,40 @@ public class MoveDataTest {
     assertEquals(moveData.coordinate, "R5");
     assertEquals(moveData.playouts, 38);
     assertEquals(moveData.winrate, 54.04, 0.01);
-    assertEquals(moveData.order, 0);
+    assertEquals(moveData.variation, Arrays.asList(
+      "R5", "Q5", "R6", "S4", "Q10", "C3", "D3", "C4", "C6", "C5", "D5"));
+  }
 
-    List<String> expected = Arrays.asList(
-      "R5", "Q5", "R6", "S4", "Q10", "C3", "D3", "C4", "C6", "C5", "D5");
+  private void testSummary(String summary, String coordinate, int playouts, double winrate, List<String> variation) {
+      MoveData moveData = MoveData.fromSummary(summary);
+      assertEquals(moveData.coordinate, coordinate);
+      assertEquals(moveData.playouts, playouts);
+      assertEquals(moveData.winrate, winrate, 0.01);
+      assertEquals(moveData.variation, variation);
+  }
 
-    assertEquals(moveData.variation, expected);
+  @Test public void summaryLine1() {
+    testSummary(" P16 ->       4 (V: 50.94%) (N:  5.79%) PV: P16 N18 R5 Q5",
+      "P16", 4, 50.94, Arrays.asList("P16", "N18", "R5", "Q5"));
+  }
+
+  @Test public void summaryLine2() {
+    testSummary("  D9 ->      59 (V: 60.61%) (N: 52.59%) PV: D9 D12 E9 C13 C15 F17",
+      "D9", 59, 60.61, Arrays.asList("D9", "D12", "E9", "C13", "C15", "F17"));
+  }
+
+  @Test public void summaryLine3() {
+    testSummary("  B2 ->       1 (V: 46.52%) (N: 86.74%) PV: B2",
+      "B2", 1, 46.52, Arrays.asList("B2"));
+  }
+
+  @Test public void summaryLine4() {
+    testSummary(" D16 ->      33 (V: 53.63%) (N: 27.64%) PV: D16 D4 Q16 O4 C3 C4",
+      "D16", 33, 53.63, Arrays.asList("D16", "D4", "Q16", "O4", "C3", "C4"));
+  }
+
+  @Test public void summaryLine5() {
+    testSummary(" Q16 ->       0 (V:  0.00%) (N:  0.52%) PV: Q16\n",
+      "Q16", 0, 0.0, Arrays.asList("Q16"));
   }
 }


### PR DESCRIPTION
This PR adds a new parser for what I've called "summary line". Leelaz will systematically output small summaries like the following once it reached the maximum number of visits specified with the `--visit` flag:

```
  O4 ->       5 (V: 53.21%) (N: 39.95%) PV: O4 F3 C6 C17
  F3 ->       4 (V: 54.48%) (N: 34.51%) PV: F3 F17 E17 F16
```

Parsing this data fixes #362.

This PR also setups JUnit and adds a few tests for the new regular expression.