### PR TITLE
next: Support display the comment of the SGF file

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -16,6 +16,7 @@ public class Config {
     public boolean showWinrate = true;
     public boolean showVariationGraph = true;
     public boolean showComment = false;
+    public int commentFontSize = 0;
     public boolean showRawBoard = false;
     public boolean showCaptured = true;
     public boolean handicapInsteadOfWinrate = false;
@@ -134,6 +135,7 @@ public class Config {
         showWinrate = uiConfig.getBoolean("show-winrate");
         showVariationGraph = uiConfig.getBoolean("show-variation-graph");
         showComment = uiConfig.optBoolean("show-comment", false);
+        commentFontSize = uiConfig.optInt("comment-font-size", 0);
         showCaptured = uiConfig.getBoolean("show-captured");
         showBestMoves = uiConfig.getBoolean("show-best-moves");
         showNextMoves = uiConfig.getBoolean("show-next-moves");

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -15,6 +15,7 @@ public class Config {
     public boolean showMoveNumber = false;
     public boolean showWinrate = true;
     public boolean showVariationGraph = true;
+    public boolean showComment = false;
     public boolean showRawBoard = false;
     public boolean showCaptured = true;
     public boolean handicapInsteadOfWinrate = false;
@@ -132,6 +133,7 @@ public class Config {
         showBranch = uiConfig.getBoolean("show-leelaz-variation");
         showWinrate = uiConfig.getBoolean("show-winrate");
         showVariationGraph = uiConfig.getBoolean("show-variation-graph");
+        showComment = uiConfig.optBoolean("show-comment", false);
         showCaptured = uiConfig.getBoolean("show-captured");
         showBestMoves = uiConfig.getBoolean("show-best-moves");
         showNextMoves = uiConfig.getBoolean("show-next-moves");
@@ -178,6 +180,9 @@ public class Config {
     }
     public void toggleShowVariationGraph() {
         this.showVariationGraph = !this.showVariationGraph;
+    }
+    public void toggleShowComment() {
+        this.showComment = !this.showComment;
     }
     public void toggleShowBestMoves() {
         this.showBestMoves = !this.showBestMoves;

--- a/src/main/java/featurecat/lizzie/gui/Input.java
+++ b/src/main/java/featurecat/lizzie/gui/Input.java
@@ -316,6 +316,10 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
                 Lizzie.config.toggleShowVariationGraph();
                 break;
 
+            case VK_T:
+                Lizzie.config.toggleShowComment();
+                break;
+
             case VK_C:
                 if (controlIsPressed(e)) {
                     Lizzie.frame.copySgf();
@@ -399,6 +403,9 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
 
     @Override
     public void mouseWheelMoved(MouseWheelEvent e) {
+        if (Lizzie.frame.processCommentMouseWheelMoved(e)) {
+            return;
+        }
         if (Lizzie.board.inAnalysisMode())
             Lizzie.board.toggleAnalysis();
         if (e.getWheelRotation() > 0) {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -21,7 +21,6 @@ import featurecat.lizzie.rules.GIBParser;
 import featurecat.lizzie.rules.SGFParser;
 import org.json.JSONObject;
 import org.json.JSONArray;
-import org.json.JSONException;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -1029,19 +1028,12 @@ public class LizzieFrame extends JFrame {
     private int drawComment(Graphics2D g, int x, int y, int w, int h, boolean full) {
         String comment = (Lizzie.board.getHistory().getData() != null && Lizzie.board.getHistory().getData().comment != null) ? Lizzie.board.getHistory().getData().comment : "";
         int cHeight = full ? h : (int)(h*0.5);
-        int fontSize = (int)(Math.min(getWidth(), getHeight()) * 0.98 * 0.03);
-        try {
-            fontSize = Lizzie.config.uiConfig.getInt("comment-font-size");
-        } catch (JSONException e) {
-            if (fontSize < 16) {
-                fontSize = 16;
-            }
-        }
+        int fontSize = Lizzie.config.commentFontSize > 0 ? Lizzie.config.commentFontSize : (int)(Math.min(getWidth(), getHeight()) * 0.98 * 0.03);
         Font font = new Font(systemDefaultFontName, Font.PLAIN, fontSize);
         commentPane.setFont(font);
         commentPane.setText(comment);
         commentPane.setSize(w, cHeight);
-        createCommentImage((comment != null && !comment.equals(this.cachedComment)) ? true : false, w, cHeight);
+        createCommentImage(comment != null && !comment.equals(this.cachedComment), w, cHeight);
         commentRect = new Rectangle(x, y + (h - cHeight), scrollPane.getWidth(), scrollPane.getHeight());
         g.drawImage(commentImage, commentRect.x, commentRect.y, commentRect.width, commentRect.height, null);
         cachedComment = comment;

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -21,6 +21,7 @@ import featurecat.lizzie.rules.GIBParser;
 import featurecat.lizzie.rules.SGFParser;
 import org.json.JSONObject;
 import org.json.JSONArray;
+import org.json.JSONException;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -30,6 +31,7 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 
+import java.awt.event.MouseWheelEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferStrategy;
@@ -68,6 +70,7 @@ public class LizzieFrame extends JFrame {
             resourceBundle.getString("LizzieFrame.commands.keyV"),
             resourceBundle.getString("LizzieFrame.commands.keyW"),
             resourceBundle.getString("LizzieFrame.commands.keyG"),
+            resourceBundle.getString("LizzieFrame.commands.keyT"),
             resourceBundle.getString("LizzieFrame.commands.keyHome"),
             resourceBundle.getString("LizzieFrame.commands.keyEnd"),
             resourceBundle.getString("LizzieFrame.commands.keyControl"),
@@ -94,6 +97,13 @@ public class LizzieFrame extends JFrame {
     private String systemDefaultFontName = new JLabel().getFont().getFontName();
 
     private long lastAutosaveTime = System.currentTimeMillis();
+
+    // Display Comment
+    private JScrollPane scrollPane = null;
+    private JTextPane commentPane = null;
+    private BufferedImage commentImage = null;
+    private String cachedComment = null;
+    private Rectangle commentRect = null;
 
     static {
         // load fonts
@@ -124,6 +134,17 @@ public class LizzieFrame extends JFrame {
         if (Lizzie.config.startMaximized) {
             setExtendedState(Frame.MAXIMIZED_BOTH); // start maximized
         }
+
+        // Comment Pane
+        commentPane = new JTextPane();
+        commentPane.setEditable(false);
+        commentPane.setMargin(new Insets(5, 5, 5, 5));
+        commentPane.setBackground(new Color(0, 0, 0, 200));
+        commentPane.setForeground(Color.WHITE);
+        scrollPane = new JScrollPane();
+        scrollPane.setViewportView(commentPane);
+        scrollPane.setBorder(null);
+        scrollPane.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
 
         setVisible(true);
 
@@ -414,7 +435,17 @@ public class LizzieFrame extends JFrame {
 
                 if (Lizzie.config.showVariationGraph) {
                     drawVariationTreeContainer(backgroundG, vx, vy, vw, vh);
-                    variationTree.draw(g, treex, treey, treew, treeh);
+                    int cHeight = 0;
+                    if (Lizzie.config.showComment) {
+                        // Draw the Comment of the Sgf
+                        cHeight = drawComment(g, vx, vy, vw, vh, false);
+                    }
+                    variationTree.draw(g, treex, treey, treew, treeh - cHeight);
+                } else {
+                    if (Lizzie.config.showComment) {
+                        // Draw the Comment of the Sgf
+                        drawComment(g, vx, topInset, vw, vh - topInset + vy, true);
+                    }
                 }
                 if (Lizzie.config.showSubBoard) {
                     try {
@@ -867,6 +898,44 @@ public class LizzieFrame extends JFrame {
         }
     }
 
+    /**
+     * Process Comment Mouse Wheel Moved
+     * 
+     * @return true when the scroll event was processed by this method
+     */
+    public boolean processCommentMouseWheelMoved(MouseWheelEvent e) {
+        if (Lizzie.config.showComment && commentRect != null && commentRect.contains(e.getX(), e.getY())) {
+            scrollPane.dispatchEvent(e);
+            createCommentImage(true, 0, 0);
+            getGraphics().drawImage(commentImage, commentRect.x, commentRect.y, commentRect.width, commentRect.height, null);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Create comment cached image
+     * 
+     * @param forceRefresh
+     * @param w
+     * @param h
+     */
+    public void createCommentImage(boolean forceRefresh, int w, int h) {
+        if (forceRefresh || commentImage == null || scrollPane.getWidth() != w || scrollPane.getHeight() != h) {
+            if (w > 0 && h > 0) {
+                scrollPane.setSize(w, h);
+            }
+            commentImage = new BufferedImage(scrollPane.getWidth(), scrollPane.getHeight(), BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2 = commentImage.createGraphics();
+            scrollPane.doLayout();
+            scrollPane.addNotify();
+            scrollPane.validate();
+            scrollPane.printAll(g2);
+            g2.dispose();
+        }
+    }
+
     private void autosaveMaybe() {
         int interval = Lizzie.config.config.getJSONObject("ui").getInt("autosave-interval-seconds") * 1000;
         long currentTime = System.currentTimeMillis();
@@ -944,5 +1013,38 @@ public class LizzieFrame extends JFrame {
 
     public void increaseMaxAlpha(int k) {
         boardRenderer.increaseMaxAlpha(k);
+    }
+
+    /**
+     * Draw the Comment of the Sgf file
+     *
+     * @param g
+     * @param x
+     * @param y
+     * @param w
+     * @param h
+     * @param full
+     * @return
+     */
+    private int drawComment(Graphics2D g, int x, int y, int w, int h, boolean full) {
+        String comment = (Lizzie.board.getHistory().getData() != null && Lizzie.board.getHistory().getData().comment != null) ? Lizzie.board.getHistory().getData().comment : "";
+        int cHeight = full ? h : (int)(h*0.5);
+        int fontSize = (int)(Math.min(getWidth(), getHeight()) * 0.98 * 0.03);
+        try {
+            fontSize = Lizzie.config.uiConfig.getInt("comment-font-size");
+        } catch (JSONException e) {
+            if (fontSize < 16) {
+                fontSize = 16;
+            }
+        }
+        Font font = new Font(systemDefaultFontName, Font.PLAIN, fontSize);
+        commentPane.setFont(font);
+        commentPane.setText(comment);
+        commentPane.setSize(w, cHeight);
+        createCommentImage((comment != null && !comment.equals(this.cachedComment)) ? true : false, w, cHeight);
+        commentRect = new Rectangle(x, y + (h - cHeight), scrollPane.getWidth(), scrollPane.getHeight());
+        g.drawImage(commentImage, commentRect.x, commentRect.y, commentRect.width, commentRect.height, null);
+        cachedComment = comment;
+        return cHeight;
     }
 }

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1028,7 +1028,12 @@ public class LizzieFrame extends JFrame {
     private int drawComment(Graphics2D g, int x, int y, int w, int h, boolean full) {
         String comment = (Lizzie.board.getHistory().getData() != null && Lizzie.board.getHistory().getData().comment != null) ? Lizzie.board.getHistory().getData().comment : "";
         int cHeight = full ? h : (int)(h*0.5);
-        int fontSize = Lizzie.config.commentFontSize > 0 ? Lizzie.config.commentFontSize : (int)(Math.min(getWidth(), getHeight()) * 0.98 * 0.03);
+        int fontSize = (int)(Math.min(getWidth(), getHeight()) * 0.0294);
+        if (Lizzie.config.commentFontSize > 0) {
+            fontSize = Lizzie.config.commentFontSize;
+        } else if (fontSize < 16) {
+            fontSize = 16;
+        }
         Font font = new Font(systemDefaultFontName, Font.PLAIN, fontSize);
         commentPane.setFont(font);
         commentPane.setText(comment);

--- a/src/main/java/featurecat/lizzie/gui/VariationTree.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTree.java
@@ -79,7 +79,7 @@ public class VariationTree {
         g.setColor(curcolor);
 
         // Draw main line
-        while (cur.next() != null && ((posy + YSPACING + DOT_DIAM) < maxposy)) { // Fix oval cover issue sometimes
+        while (cur.next() != null && posy + YSPACING < maxposy) {
             posy += YSPACING;
             cur = cur.next();
             if (cur == curMove)  {

--- a/src/main/java/featurecat/lizzie/gui/VariationTree.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTree.java
@@ -79,7 +79,7 @@ public class VariationTree {
         g.setColor(curcolor);
 
         // Draw main line
-        while (cur.next() != null && posy + YSPACING < maxposy) {
+        while (cur.next() != null && ((posy + YSPACING + DOT_DIAM) < maxposy)) { // Fix oval cover issue sometimes
             posy += YSPACING;
             cur = cur.next();
             if (cur == curMove)  {

--- a/src/main/java/featurecat/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardHistoryList.java
@@ -89,20 +89,6 @@ public class BoardHistoryList {
     }
 
     /**
-     * moves the pointer to the right, returns the node stored there
-     *
-     * @return the next node, null if there is no next node
-     */
-    public BoardHistoryNode nextNode() {
-        if (head.next() == null)
-            return null;
-        else
-            head = head.next();
-
-        return head;
-    }
-
-    /**
      * moves the pointer to the variation number idx, returns the data stored there
      *
      * @return the data of next node, null if there is no variaton with index

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -25,6 +25,7 @@ LizzieFrame.commands.keyEnd=end|go to end
 LizzieFrame.commands.keyEnter=enter|force Leela Zero move
 LizzieFrame.commands.keyF=f|toggle next move display
 LizzieFrame.commands.keyG=g|toggle variation graph
+LizzieFrame.commands.keyT=t|toggle comment display
 LizzieFrame.commands.keyHome=home|go to start
 LizzieFrame.commands.keyI=i|edit game info
 LizzieFrame.commands.keyA=a|run automatic analysis of game

--- a/src/main/resources/l10n/DisplayStrings_RO.properties
+++ b/src/main/resources/l10n/DisplayStrings_RO.properties
@@ -24,6 +24,7 @@ LizzieFrame.commands.keyEnd=end|mergi la sfârșit
 LizzieFrame.commands.keyEnter=enter|forțează mutarea lui Leela Zero
 LizzieFrame.commands.keyF=f|afișează/ascunde următoarea mutare
 LizzieFrame.commands.keyG=g|afișează/ascunde graficul cu variante
+LizzieFrame.commands.keyT=t|afișează/ascunde comentariul
 LizzieFrame.commands.keyHome=home|mergi la început
 LizzieFrame.commands.keyI=i|editează informațiile jocului
 LizzieFrame.commands.keyA=a|rulează analiza automată a jocului

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -13,6 +13,7 @@ LizzieFrame.commands.keyEnd=end|\u8DF3\u5230\u68CB\u8C31\u672B\u5C3E
 LizzieFrame.commands.keyEnter=enter|\u8BA9Leela Zero\u843D\u5B50
 LizzieFrame.commands.keyF=f|\u663E\u793A/\u9690\u85CF\u4E0B\u4E00\u624B
 LizzieFrame.commands.keyG=g|\u663E\u793A/\u9690\u85CF\u5206\u652F\u56FE
+LizzieFrame.commands.keyT=t|\u663E\u793A/\u9690\u85CF\u8BC4\u8BBA
 LizzieFrame.commands.keyHome=home|\u8DF3\u8F6C\u5230\u68CB\u8C31\u5F00\u5934
 LizzieFrame.commands.keyI=i|\u7F16\u8F91\u68CB\u5C40\u4FE1\u606F
 LizzieFrame.commands.keyA=a|\u8FD0\u884C\u7B80\u5355\u7684\u81EA\u52A8\u5168\u76D8\u5206\u6790


### PR DESCRIPTION
Closes:    #350 

This pull request based on #364 

1. Support for displaying comments of the sgf files.
    Default is close, can press key 'T' to toggle, and add a item 'show-comment' in the config file.
    ![image](https://user-images.githubusercontent.com/42595514/45953682-6f70c680-c03d-11e8-80f3-8f57b2963543.png)

2. Allow use a hidden item 'comment-font-size' in the config to forced specify the comment font size, for example:
    "comment-font-size": 20