### PR TITLE
next: Support Display Only Last Move Number

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -470,7 +470,7 @@ public class BoardRenderer {
         int[] moveNumberList = branch == null ? Lizzie.board.getMoveNumberList() : branch.data.moveNumberList;
 
         // Allow to display only last move number
-        int lastMoveNumber = Lizzie.board.getData().moveNumber;
+        int lastMoveNumber = branch == null ? Lizzie.board.getData().moveNumber : branch.data.moveNumber;
         int onlyLastMoveNumber = Lizzie.config.uiConfig.optInt("only-last-move-number", 9999);
 
         for (int i = 0; i < Board.BOARD_SIZE; i++) {

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -471,8 +471,8 @@ public class BoardRenderer {
 
         // Allow to display only last move number
         int lastMoveNumber = Lizzie.board.getData().moveNumber;
-        int onlyLastMoveNumber = (!Lizzie.config.uiConfig.isNull("only-last-move-number")) ? Lizzie.config.uiConfig.getInt("only-last-move-number") : 9999;
-        
+        int onlyLastMoveNumber = Lizzie.config.uiConfig.optInt("only-last-move-number", 9999);
+
         for (int i = 0; i < Board.BOARD_SIZE; i++) {
             for (int j = 0; j < Board.BOARD_SIZE; j++) {
                 int stoneX = x + scaledMargin + squareLength * i;

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -469,10 +469,19 @@ public class BoardRenderer {
 
         int[] moveNumberList = branch == null ? Lizzie.board.getMoveNumberList() : branch.data.moveNumberList;
 
+        // Allow to display only last move number
+        int lastMoveNumber = Lizzie.board.getData().moveNumber;
+        int onlyLastMoveNumber = (!Lizzie.config.uiConfig.isNull("only-last-move-number")) ? Lizzie.config.uiConfig.getInt("only-last-move-number") : 9999;
+        
         for (int i = 0; i < Board.BOARD_SIZE; i++) {
             for (int j = 0; j < Board.BOARD_SIZE; j++) {
                 int stoneX = x + scaledMargin + squareLength * i;
                 int stoneY = y + scaledMargin + squareLength * j;
+
+                // Allow to display only last move number
+                if (lastMoveNumber - moveNumberList[Board.getIndex(i, j)] >= onlyLastMoveNumber) {
+                    continue;
+                }
 
                 Stone stoneAtThisPoint = branch == null ? Lizzie.board.getStones()[Board.getIndex(i, j)] :
                         branch.data.stones[Board.getIndex(i, j)];


### PR DESCRIPTION
The change supports display only last move number that can be specified in the config.txt.
For example, only display last 10 move number:

"ui": {
    "only-last-move-number": 10,

![image](https://user-images.githubusercontent.com/42595514/45635401-721c6a80-bad7-11e8-8640-ea9f675bc184.png)