### PR TITLE
Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+jdk: oraclejdk8
+
+# The latest linux image on Travis is too old to build leelaz, what a shame...
+os: osx
+
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.leelaz
+
+install:
+  - sh scripts/make-leelaz.sh
+  - sh scripts/download-network.sh
+
+script:
+  - mvn test
+  - mvn com.coveo:fmt-maven-plugin:check

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Lizzie is a graphical interface allowing the user to analyze games in
 real time using [Leela Zero](https://github.com/gcp/leela-zero). You
 need Java 8 or higher to run this program.
 
+<img src="https://travis-ci.org/featurecat/lizzie.svg?branch=master">
+
 ## Running a release
 
 Just follow the instructions in the provided readme in the

--- a/scripts/download-network.sh
+++ b/scripts/download-network.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eux
+
+HASH="d351f06e446ba10697bfd2977b4be52c3de148032865eaaf9efc9796aea95a0c"
+CACHE="$HOME/.leelaz"
+TARGET="$CACHE/$HASH.gz"
+
+if ! test -f "$TARGET"; then
+  mkdir -p "$CACHE"
+  url="http://zero.sjeng.org/networks/$HASH.gz"
+  curl --output "$TARGET" "$url"
+fi
+
+cp "$TARGET" ./network.gz

--- a/scripts/make-leelaz.sh
+++ b/scripts/make-leelaz.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -eux
+
+COMMIT="73f1f934169a62d7b054aefccecb41029de0fc5f"
+CACHE="$HOME/.leelaz"
+TARGET="$CACHE/leelaz-$COMMIT"
+
+mkdir -p "$CACHE"
+
+if ! test -f "$TARGET"; then
+  if test "$(uname)" == "Linux"; then
+    sudo apt install -y            \
+      cmake                        \
+      libboost-dev                 \
+      libboost-filesystem-dev      \
+      libboost-program-options-dev \
+      libopenblas-dev              \
+      opencl-headers               \
+      ocl-icd-libopencl1           \
+      ocl-icd-opencl-dev           \
+      zlib1g-dev
+  elif test "$(uname)" == "FreeBSD"; then
+    brew install boost || true
+    brew install cmake || true
+  fi
+
+  # Get next, on a stable commit
+  git clone https://github.com/gcp/leela-zero || true
+  cd leela-zero
+  git reset --hard "$COMMIT"
+  git submodule update --init --recursive
+
+  # Configure CPU only
+  sed -i.bak '/#define USE_OPENCL/d' src/config.h
+
+  # Build leelaz
+  mkdir -p build && cd build
+  cmake ..
+  cmake --build .
+
+  mv "leelaz" "$TARGET"
+  cd ../..
+fi
+
+cp "$TARGET" ./leelaz


### PR DESCRIPTION
This PR setups Travic CI to check the following on every pull request:

- The code compiles
- The test pass
- The code conforms to the Google Java Style (which everyone should get for free when running `mvn compile`)

I've included two shell scripts to compile Leela Zero and download a latest 192x15 network, both of which are required to get the tests passing. I've also setup the Travis caches to prevent recompiling leelaz and re-dowloading the network on every PR. As a result, the CI is blasting fast: it runs under [45 seconds](https://travis-ci.org/OlivierBlanvillain/lizzie/builds/438407131?utm_source=github_status&utm_medium=notification) (but that's also because we have like two tests ^^').

I had to use the Mac OS image from Travis because the Linux they provide is too old to compile leelaz, and switching to mac/brew was simpler than recompiling boosts from source on the CI. I left the `apt` commands to install the leelaz dependencies on Debian based distro for documentation and possibly future uses once Travis updates their Linux distribution.

@featurecat To finalize this I now need to go to https://travis-ci.org/, sign in, and unable the `featurecat/lizzie`. It shouldn't take more than 5 minutes, and after you've done that and we merged this PR we should get every pull request compiled and tested from Travis!