### PR TITLE
Repaint board when mouse leaves it showing branch.

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -988,7 +988,7 @@ public class LizzieFrame extends JFrame {
 
   public void onMouseMoved(int x, int y) {
     int[] c = boardRenderer.convertScreenToCoordinates(x, y);
-    if (c != null && !isMouseOver(c[0], c[1])) {
+    if (c == null ? boardRenderer.isShowingBranch() : !isMouseOver(c[0], c[1])) {
       repaint();
     }
     mouseOverCoordinate = c;


### PR DESCRIPTION
Right now, whenever a branch is being shown and pondering is off, only going to an unvisited intersection will bring back the move statistics, not moving the cursor away from the board.