### PR TITLE
Stricter screen-to-coordinates conversion.

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -1142,8 +1142,8 @@ public class BoardRenderer {
     int squareSize = calculateSquareLength(boardLengthWithoutMargins);
 
     // transform the pixel coordinates to board coordinates
-    x = (x - this.x - marginLength + squareSize / 2) / squareSize;
-    y = (y - this.y - marginLength + squareSize / 2) / squareSize;
+    x = Math.floorDiv(x - this.x - marginLength + squareSize / 2, squareSize);
+    y = Math.floorDiv(y - this.y - marginLength + squareSize / 2, squareSize);
 
     // return these values if they are valid board coordinates
     return Board.isValid(x, y) ? Optional.of(new int[] {x, y}) : Optional.empty();


### PR DESCRIPTION
Because integer division rounds towards zero rather than negative infinity, the code currently maps some points off the board to coordinates on the first row and/or column.