### PR TITLE
Reconfigured Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
-jdk: oraclejdk8
-
-# The latest linux image on Travis is too old to build leelaz, what a shame...
 os: osx
+osx_image: xcode9.3
 
 cache:
   directories:


### PR DESCRIPTION
Travis has been broken for a while. Using the correct image to enable Java 8 from https://docs.travis-ci.com/user/reference/osx/#jdk-and-os-x