### PR TITLE
fixed: Default to turn off the hold winrate in the move

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -73,6 +73,7 @@ public class Config {
   public Optional<Map<Double, Color>> blunderNodeColors;
   public int nodeColorMode = 0;
   public boolean appendWinrateToComment = true;
+  public boolean holdWinrateToMove = false;
   public int boardPositionProportion = 4;
   public String gtpConsoleStyle = "";
   private final String defaultGtpConsoleStyle =
@@ -182,6 +183,7 @@ public class Config {
     handicapInsteadOfWinrate = uiConfig.getBoolean("handicap-instead-of-winrate");
     showDynamicKomi = uiConfig.getBoolean("show-dynamic-komi");
     appendWinrateToComment = uiConfig.optBoolean("append-winrate-to-comment");
+    holdWinrateToMove = uiConfig.optBoolean("hold-wnrate-to-move");
     showCoordinates = uiConfig.optBoolean("show-coordinates");
     replayBranchIntervalSeconds = uiConfig.optDouble("replay-branch-interval-seconds", 1.0);
     colorByWinrateInsteadOfVisits = uiConfig.optBoolean("color-by-winrate-instead-of-visits");

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -183,7 +183,7 @@ public class Config {
     handicapInsteadOfWinrate = uiConfig.getBoolean("handicap-instead-of-winrate");
     showDynamicKomi = uiConfig.getBoolean("show-dynamic-komi");
     appendWinrateToComment = uiConfig.optBoolean("append-winrate-to-comment");
-    holdWinrateToMove = uiConfig.optBoolean("hold-wnrate-to-move");
+    holdWinrateToMove = uiConfig.optBoolean("hold-winrate-to-move");
     showCoordinates = uiConfig.optBoolean("show-coordinates");
     replayBranchIntervalSeconds = uiConfig.optDouble("replay-branch-interval-seconds", 1.0);
     colorByWinrateInsteadOfVisits = uiConfig.optBoolean("color-by-winrate-instead-of-visits");

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -218,7 +218,9 @@ public class Leelaz {
         bestMoves.add(MoveData.fromInfo(var));
       }
     }
-    Lizzie.board.getData().tryToSetBestMoves(bestMoves);
+    if (Lizzie.config.holdWinrateToMove) {
+      Lizzie.board.getData().tryToSetBestMoves(bestMoves);
+    }
     return bestMoves;
   }
 
@@ -575,7 +577,9 @@ public class Leelaz {
       // copy the list to avoid concurrent modification exception... TODO there must be a better way
       // (note the concurrent modification exception is very very rare)
       // We should use Lizzie Board's best moves as they will generally be the most accurate
-      final List<MoveData> moves = new ArrayList<MoveData>(Lizzie.board.getData().bestMoves);
+      final List<MoveData> moves =
+          new ArrayList<MoveData>(
+              Lizzie.config.holdWinrateToMove ? Lizzie.board.getData().bestMoves : bestMoves);
 
       // get the total number of playouts in moves
       int totalPlayouts = moves.stream().mapToInt(move -> move.playouts).sum();

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -375,8 +375,10 @@ public class BoardRenderer {
 
     // calculate best moves and branch
     bestMoves = Lizzie.leelaz.getBestMoves();
-    if (MoveData.getPlayouts(bestMoves) < Lizzie.board.getData().getPlayouts()) {
-      bestMoves = Lizzie.board.getData().bestMoves;
+    if (Lizzie.config.holdWinrateToMove) {
+      if (MoveData.getPlayouts(bestMoves) < Lizzie.board.getData().getPlayouts()) {
+        bestMoves = Lizzie.board.getData().bestMoves;
+      }
     }
 
     variationOpt = Optional.empty();

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1359,6 +1359,9 @@ public class Board implements LeelazListener {
       history.getData().winrate = stats.maxWinrate;
       // we won't set playouts here. but setting winrate is ok... it shows the user that we are
       // computing. i think its fine.
+      if (!Lizzie.config.holdWinrateToMove) {
+        history.getData().setPlayouts(stats.totalPlayouts);
+      }
     }
   }
 

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -199,7 +199,7 @@ public class SGFParser {
             } else {
               Lizzie.board.comment(tagContent);
             }
-          } else if (tag.equals("LZ")) {
+          } else if (tag.equals("LZ") && Lizzie.config.holdWinrateToMove) {
             // Content contains data for Lizzie to read
             String[] lines = tagContent.split("\n");
             String[] line1 = lines[0].split(" ");
@@ -475,7 +475,9 @@ public class SGFParser {
         }
 
         // Add LZ specific data to restore on next load
-        builder.append(String.format("LZ[%s]", formatNodeData(node)));
+        if (Lizzie.config.holdWinrateToMove) {
+          builder.append(String.format("LZ[%s]", formatNodeData(node)));
+        }
       }
 
       if (node.numberOfChildren() > 1) {


### PR DESCRIPTION
Fixed the commit:  c5d92dfee78779c4e12e269dce1247bdce426b08

Default to turn off the hold winrate in the move.

Keeping the winrate in the move, the interface will become lagging when the visits and branch is large.
It is turned off by default before optimization, and the user can open it manually by hold-winrate-to-move: true.