### PR TITLE
Fix appbundler maven plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,18 @@
                     </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-archiver</artifactId>
+                        <version>4.1.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-velocity</artifactId>
+                        <version>1.2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
To address the issue in #522 and thank @scw1109 's investigation.

My env: 
Apache Maven 3.6.1
JDK: openjdk 12.0.1 2019-04-16
OS name: "mac os x", version: "10.14.5", arch: "x86_64", family: "mac"