### PR TITLE
Don't modify cachedEsitmateRectImage incrementally; should fix #569.

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -1571,8 +1571,8 @@ public class BoardRenderer {
     if (boardWidth <= 0 || boardHeight <= 0) {
       return;
     }
-    cachedEsitmateRectImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
-    Graphics2D g = cachedEsitmateRectImage.createGraphics();
+    BufferedImage newEstimateImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
+    Graphics2D g = newEstimateImage.createGraphics();
     for (int i = 0; i < esitmateArray.size(); i++) {
 
       if ((esitmateArray.get(i) > 0 && Lizzie.board.getHistory().isBlacksTurn())
@@ -1610,6 +1610,7 @@ public class BoardRenderer {
             (int) (stoneRadius * 1.2));
       }
     }
+    cachedEsitmateRectImage = newEstimateImage;
   }
 
   public void drawEstimateRectZen(ArrayList<Integer> esitmateArray) {


### PR DESCRIPTION
In BoardRenderer.drawEstimateRectKata, make a new overlay image and write everything to it before swapping it over, hopefully atomically, into cachedEsitmateRectImage. This should prevent the flickering and occasional corruption described in #569.