### PR TITLE
Add null check

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -1348,13 +1348,15 @@ public class Menu extends JMenuBar {
   }
 
   public void updateEngineIcon(List<Leelaz> engineList, int currentEngineNo) {
-    for (int i = 0; i < engineList.size(); i++) {
-      Leelaz engineDt = engineList.get(i);
-      if (engineDt != null) {
-        if (i == currentEngineNo) {
-          engine[i].setIcon(running);
-          engineMenu.setText(engine[i].getText());
-        } else if (engineDt.isLoaded()) engine[i].setIcon(ready);
+    if (engine != null) {
+      for (int i = 0; i < engineList.size(); i++) {
+        Leelaz engineDt = engineList.get(i);
+        if (engineDt != null) {
+          if (i == currentEngineNo) {
+            engine[i].setIcon(running);
+            engineMenu.setText(engine[i].getText());
+          } else if (engineDt.isLoaded()) engine[i].setIcon(ready);
+        }
       }
     }
   }


### PR DESCRIPTION
The communication breakdown with the engine as mentioned in https://github.com/featurecat/lizzie/issues/580#issuecomment-515532209 and https://github.com/featurecat/lizzie/pull/577#issuecomment-518887275 was ultimately due to a simple null-pointer exception.