### PR TITLE
Fix an encoding issue

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -40,6 +40,7 @@ public class SGFParser {
     }
 
     String encoding = EncodingDetector.detect(filename);
+    if (encoding == "WINDOWS-1252") encoding = "gb2312";
     FileInputStream fp = new FileInputStream(file);
     InputStreamReader reader = new InputStreamReader(fp, encoding);
     StringBuilder builder = new StringBuilder();
@@ -279,7 +280,8 @@ public class SGFParser {
               line2 = lines[1];
             }
             String versionNumber = line1[0];
-            line1[1] = line1[1].replaceAll(",", "."); // fix a decimal representation localization issue
+            line1[1] =
+                line1[1].replaceAll(",", "."); // fix a decimal representation localization issue
             Lizzie.board.getData().winrate = 100 - Double.parseDouble(line1[1]);
             int numPlayouts =
                 Integer.parseInt(


### PR DESCRIPTION

[20191005-9454.zip](https://github.com/featurecat/lizzie/files/3701223/20191005-9454.zip)
Its a Sgf from QQ group, displayed as garbled character beacuse of wrong encoding detecting.
![10081](https://user-images.githubusercontent.com/49384584/66375913-14f49f00-e9e1-11e9-9a60-c9960b9262c8.png)
this is right:
![10082](https://user-images.githubusercontent.com/49384584/66375912-14f49f00-e9e1-11e9-9d50-940038253c29.png)
