### PR TITLE
Fixed: Allow user turn on/off the border and the board border is no longer supported

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BasicInfoPane.java
+++ b/src/main/java/featurecat/lizzie/gui/BasicInfoPane.java
@@ -75,23 +75,25 @@ public class BasicInfoPane extends LizziePane {
     g.fillRect(posX, posY, width, height);
 
     // border. does not include bottom edge
-    int strokeRadius = 3;
+    int strokeRadius = Lizzie.config.showBorder ? 3 : 1;
     g.setStroke(new BasicStroke(strokeRadius == 1 ? strokeRadius : 2 * strokeRadius));
-    g.drawLine(
-        posX + strokeRadius,
-        posY + strokeRadius,
-        posX - strokeRadius + width,
-        posY + strokeRadius);
-    g.drawLine(
-        posX + strokeRadius,
-        posY + 3 * strokeRadius,
-        posX + strokeRadius,
-        posY - strokeRadius + height);
-    g.drawLine(
-        posX - strokeRadius + width,
-        posY + 3 * strokeRadius,
-        posX - strokeRadius + width,
-        posY - strokeRadius + height);
+    if (Lizzie.config.showBorder) {
+      g.drawLine(
+          posX + strokeRadius,
+          posY + strokeRadius,
+          posX - strokeRadius + width,
+          posY + strokeRadius);
+      g.drawLine(
+          posX + strokeRadius,
+          posY + 3 * strokeRadius,
+          posX + strokeRadius,
+          posY - strokeRadius + height);
+      g.drawLine(
+          posX - strokeRadius + width,
+          posY + 3 * strokeRadius,
+          posX - strokeRadius + width,
+          posY - strokeRadius + height);
+    }
 
     // Draw middle line
     g.drawLine(

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -1042,16 +1042,17 @@ public class BoardRenderer {
           boardWidth + 4 * shadowRadius,
           boardHeight + 4 * shadowRadius);
 
-      if (Lizzie.config.showBorder) {
-        g.setStroke(new BasicStroke(shadowRadius * 2));
-        // draw border
-        g.setColor(new Color(0, 0, 0, 50));
-        g.drawRect(
-            x - shadowRadius,
-            y - shadowRadius,
-            boardWidth + 2 * shadowRadius,
-            boardHeight + 2 * shadowRadius);
-      }
+      // The board border is no longer supported, add another option if needed
+      //      if (Lizzie.config.showBorder) {
+      //        g.setStroke(new BasicStroke(shadowRadius * 2));
+      //        // draw border
+      //        g.setColor(new Color(0, 0, 0, 50));
+      //        g.drawRect(
+      //            x - shadowRadius,
+      //            y - shadowRadius,
+      //            boardWidth + 2 * shadowRadius,
+      //            boardHeight + 2 * shadowRadius);
+      //      }
       g.setStroke(new BasicStroke(1));
 
     } else {
@@ -1511,8 +1512,11 @@ public class BoardRenderer {
    * @param boardLength the boardLength of the board
    */
   public void setBoardLength(int boardWidth, int boardHeight) {
-    this.shadowRadius =
-        Lizzie.config.showBorder ? (int) (max(boardWidth, boardHeight) * MARGIN / 6) : 0;
+    // The board border is no longer supported, add another option if needed
+    //    this.shadowRadius =
+    //        Lizzie.config.showBorder ? (int) (max(boardWidth, boardHeight) * MARGIN / 6) :
+    // 0;this.shadowRadius =
+    this.shadowRadius = 0;
     this.boardWidth = boardWidth - 4 * shadowRadius;
     this.boardHeight = boardHeight - 4 * shadowRadius;
     this.x = x + 2 * shadowRadius;
@@ -1534,8 +1538,10 @@ public class BoardRenderer {
     // re-center board
     //    setLocation(x + (boardWidth0 - boardWidth) / 2, y + (boardHeight0 - boardHeight) / 2);
 
-    this.shadowRadius =
-        Lizzie.config.showBorder ? (int) (max(boardWidth, boardHeight) * MARGIN / 6) : 0;
+    // The board border is no longer supported, add another option if needed
+    //    this.shadowRadius =
+    //        Lizzie.config.showBorder ? (int) (max(boardWidth, boardHeight) * MARGIN / 6) : 0;
+    this.shadowRadius = 0;
     this.boardWidth = boardWidth - 4 * shadowRadius;
     this.boardHeight = boardHeight - 4 * shadowRadius;
     this.x = x + 2 * shadowRadius;

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -172,6 +172,7 @@ public class ConfigDialog extends JDialog {
   public JRadioButton rdoShowMoveNumberLast;
   public JTextField txtShowMoveNumber;
   public JCheckBox chkShowBlunderBar;
+  public JCheckBox chkShowBorder;
   public JCheckBox chkDynamicWinrateGraphWidth;
   public JCheckBox chkAppendWinrateToComment;
   public JCheckBox chkHoldBestMovesToSgf;
@@ -983,6 +984,13 @@ public class ConfigDialog extends JDialog {
     chkShowSubBoard.setBounds(170, 116, 57, 23);
     uiTab.add(chkShowSubBoard);
 
+    JLabel lblShowBorder = new JLabel(resourceBundle.getString("LizzieConfig.title.showBorder"));
+    lblShowBorder.setBounds(372, 119, 157, 16);
+    uiTab.add(lblShowBorder);
+    chkShowBorder = new JCheckBox("");
+    chkShowBorder.setBounds(536, 116, 57, 23);
+    uiTab.add(chkShowBorder);
+
     JLabel lblShowCoordinates =
         new JLabel(resourceBundle.getString("LizzieConfig.title.showCoordinates"));
     lblShowCoordinates.setBounds(6, 146, 157, 16);
@@ -1187,6 +1195,7 @@ public class ConfigDialog extends JDialog {
     chkShowSubBoard.setSelected(Lizzie.config.showSubBoard);
     chkShowCoordinates.setSelected(Lizzie.config.showCoordinates);
     chkShowBlunderBar.setSelected(Lizzie.config.showBlunderBar);
+    chkShowBorder.setSelected(Lizzie.config.showBorder);
     chkDynamicWinrateGraphWidth.setSelected(Lizzie.config.dynamicWinrateGraphWidth);
     chkAppendWinrateToComment.setSelected(Lizzie.config.appendWinrateToComment);
     chkHoldBestMovesToSgf.setSelected(Lizzie.config.holdBestMovesToSgf);
@@ -2504,6 +2513,8 @@ public class ConfigDialog extends JDialog {
 
       Lizzie.config.showBlunderBar = chkShowBlunderBar.isSelected();
       Lizzie.config.uiConfig.putOpt("show-blunder-bar", Lizzie.config.showBlunderBar);
+      Lizzie.config.showBorder = chkShowBorder.isSelected();
+      Lizzie.config.uiConfig.putOpt("show-border", Lizzie.config.showBorder);
       Lizzie.config.dynamicWinrateGraphWidth = chkDynamicWinrateGraphWidth.isSelected();
       Lizzie.config.uiConfig.putOpt(
           "dynamic-winrate-graph-width", Lizzie.config.dynamicWinrateGraphWidth);

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -826,14 +826,16 @@ public class LizzieFrame extends MainFrame {
 
     g.setColor(new Color(0, 0, 0, 130));
     g.fillRect(commandsX, commandsY, boxWidth, boxHeight);
-    int strokeRadius = 2;
+    int strokeRadius = Lizzie.config.showBorder ? 2 : 1;
     g.setStroke(new BasicStroke(strokeRadius == 1 ? strokeRadius : 2 * strokeRadius));
-    g.setColor(new Color(0, 0, 0, 60));
-    g.drawRect(
-        commandsX + strokeRadius,
-        commandsY + strokeRadius,
-        boxWidth - 2 * strokeRadius,
-        boxHeight - 2 * strokeRadius);
+    if (Lizzie.config.showBorder) {
+      g.setColor(new Color(0, 0, 0, 60));
+      g.drawRect(
+          commandsX + strokeRadius,
+          commandsY + strokeRadius,
+          boxWidth - 2 * strokeRadius,
+          boxHeight - 2 * strokeRadius);
+    }
     int verticalLineX = (int) (commandsX + boxWidth * 0.3);
     g.setColor(new Color(0, 0, 0, 60));
     g.drawLine(
@@ -870,7 +872,7 @@ public class LizzieFrame extends MainFrame {
 
     Font font = new Font(Lizzie.config.fontName, Font.PLAIN, (int) (maxSize * 0.03));
     String commandString = resourceBundle.getString("LizzieFrame.prompt.showControlsHint");
-    int strokeRadius = 2;
+    int strokeRadius = Lizzie.config.showBorder ? 2 : 0;
 
     int showCommandsHeight = (int) (font.getSize() * 1.1);
     int showCommandsWidth = g.getFontMetrics(font).stringWidth(commandString) + 4 * strokeRadius;
@@ -878,13 +880,15 @@ public class LizzieFrame extends MainFrame {
     int showCommandsY = mainPanel.getHeight() - showCommandsHeight - mainPanel.getInsets().bottom;
     g.setColor(new Color(0, 0, 0, 130));
     g.fillRect(showCommandsX, showCommandsY, showCommandsWidth, showCommandsHeight);
-    g.setStroke(new BasicStroke(2 * strokeRadius));
-    g.setColor(new Color(0, 0, 0, 60));
-    g.drawRect(
-        showCommandsX + strokeRadius,
-        showCommandsY + strokeRadius,
-        showCommandsWidth - 2 * strokeRadius,
-        showCommandsHeight - 2 * strokeRadius);
+    if (Lizzie.config.showBorder) {
+      g.setStroke(new BasicStroke(2 * strokeRadius));
+      g.setColor(new Color(0, 0, 0, 60));
+      g.drawRect(
+          showCommandsX + strokeRadius,
+          showCommandsY + strokeRadius,
+          showCommandsWidth - 2 * strokeRadius,
+          showCommandsHeight - 2 * strokeRadius);
+    }
     g.setStroke(new BasicStroke(1));
 
     g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -936,17 +940,19 @@ public class LizzieFrame extends MainFrame {
     g.fillRect(posX, posY, width, height);
 
     // border. does not include bottom edge
-    int strokeRadius = 3;
+    int strokeRadius = Lizzie.config.showBorder ? 3 : 1;
     g.setStroke(new BasicStroke(strokeRadius == 1 ? strokeRadius : 2 * strokeRadius));
     g.drawLine(
         posX + strokeRadius, posY + strokeRadius,
         posX - strokeRadius + width, posY + strokeRadius);
-    g.drawLine(
-        posX + strokeRadius, posY + 3 * strokeRadius,
-        posX + strokeRadius, posY - strokeRadius + height);
-    g.drawLine(
-        posX - strokeRadius + width, posY + 3 * strokeRadius,
-        posX - strokeRadius + width, posY - strokeRadius + height);
+    if (Lizzie.config.showBorder) {
+      g.drawLine(
+          posX + strokeRadius, posY + 3 * strokeRadius,
+          posX + strokeRadius, posY - strokeRadius + height);
+      g.drawLine(
+          posX - strokeRadius + width, posY + 3 * strokeRadius,
+          posX - strokeRadius + width, posY - strokeRadius + height);
+    }
 
     // resize the box now so it's inside the border
     posX += 2 * strokeRadius;
@@ -1067,20 +1073,25 @@ public class LizzieFrame extends MainFrame {
     g.fillRect(posX, posY, width, height);
 
     // border. does not include bottom edge
-    int strokeRadius = 3;
+    int strokeRadius = Lizzie.config.showBorder ? 3 : 1;
     g.setStroke(new BasicStroke(strokeRadius == 1 ? strokeRadius : 2 * strokeRadius));
-    g.drawLine(
-        posX + strokeRadius, posY + strokeRadius, posX - strokeRadius + width, posY + strokeRadius);
-    g.drawLine(
-        posX + strokeRadius,
-        posY + 3 * strokeRadius,
-        posX + strokeRadius,
-        posY - strokeRadius + height);
-    g.drawLine(
-        posX - strokeRadius + width,
-        posY + 3 * strokeRadius,
-        posX - strokeRadius + width,
-        posY - strokeRadius + height);
+    if (Lizzie.config.showBorder) {
+      g.drawLine(
+          posX + strokeRadius,
+          posY + strokeRadius,
+          posX - strokeRadius + width,
+          posY + strokeRadius);
+      g.drawLine(
+          posX + strokeRadius,
+          posY + 3 * strokeRadius,
+          posX + strokeRadius,
+          posY - strokeRadius + height);
+      g.drawLine(
+          posX - strokeRadius + width,
+          posY + 3 * strokeRadius,
+          posX - strokeRadius + width,
+          posY - strokeRadius + height);
+    }
 
     // Draw middle line
     g.drawLine(

--- a/src/main/java/featurecat/lizzie/gui/VariationTree.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTree.java
@@ -238,21 +238,23 @@ public class VariationTree {
     YSPACING = (Lizzie.config.showLargeSubBoard() ? 20 : 30);
     XSPACING = YSPACING;
 
-    int strokeRadius = 2;
+    int strokeRadius = Lizzie.config.showBorder ? 2 : 0;
     if (!calc) {
       // Draw background
       area.setBounds(posx, posy, width, height);
       g.setColor(new Color(0, 0, 0, 60));
       g.fillRect(posx, posy, width, height);
 
-      // draw edge of panel
-      g.setStroke(new BasicStroke(2 * strokeRadius));
-      g.drawLine(
-          posx + strokeRadius,
-          posy + strokeRadius,
-          posx + strokeRadius,
-          posy - strokeRadius + height);
-      g.setStroke(new BasicStroke(1));
+      if (Lizzie.config.showBorder) {
+        // draw edge of panel
+        g.setStroke(new BasicStroke(2 * strokeRadius));
+        g.drawLine(
+            posx + strokeRadius,
+            posy + strokeRadius,
+            posx + strokeRadius,
+            posy - strokeRadius + height);
+        g.setStroke(new BasicStroke(1));
+      }
     }
 
     int middleY = posy + height / 2;

--- a/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
@@ -45,14 +45,20 @@ public class WinrateGraph {
     g.fillRect(posx, posy, width, height);
 
     // draw border
-    int strokeRadius = 3;
+    int strokeRadius = Lizzie.config.showBorder ? 3 : 1;
     g.setStroke(new BasicStroke(strokeRadius == 1 ? strokeRadius : 2 * strokeRadius));
     g.setPaint(borderGradient);
-    g.drawRect(
-        posx + strokeRadius,
-        posy + strokeRadius,
-        width - 2 * strokeRadius,
-        height - 2 * strokeRadius);
+    if (Lizzie.config.showBorder) {
+      g.drawRect(
+          posx + strokeRadius,
+          posy + strokeRadius,
+          width - 2 * strokeRadius,
+          height - 2 * strokeRadius);
+    } else {
+      g.drawLine(
+          posx + strokeRadius, posy + strokeRadius,
+          posx - strokeRadius + width, posy + strokeRadius);
+    }
 
     g.setPaint(original);
 

--- a/src/main/java/featurecat/lizzie/gui/WinratePane.java
+++ b/src/main/java/featurecat/lizzie/gui/WinratePane.java
@@ -145,17 +145,19 @@ public class WinratePane extends LizziePane {
     g.fillRect(posX, posY, width, height);
 
     // border. does not include bottom edge
-    int strokeRadius = 3;
+    int strokeRadius = Lizzie.config.showBorder ? 3 : 1;
     g.setStroke(new BasicStroke(strokeRadius == 1 ? strokeRadius : 2 * strokeRadius));
     g.drawLine(
         posX + strokeRadius, posY + strokeRadius,
         posX - strokeRadius + width, posY + strokeRadius);
-    g.drawLine(
-        posX + strokeRadius, posY + 3 * strokeRadius,
-        posX + strokeRadius, posY - strokeRadius + height);
-    g.drawLine(
-        posX - strokeRadius + width, posY + 3 * strokeRadius,
-        posX - strokeRadius + width, posY - strokeRadius + height);
+    if (Lizzie.config.showBorder) {
+      g.drawLine(
+          posX + strokeRadius, posY + 3 * strokeRadius,
+          posX + strokeRadius, posY - strokeRadius + height);
+      g.drawLine(
+          posX - strokeRadius + width, posY + 3 * strokeRadius,
+          posX - strokeRadius + width, posY - strokeRadius + height);
+    }
 
     // resize the box now so it's inside the border
     posX += 2 * strokeRadius;

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -102,6 +102,7 @@ LizzieConfig.title.showMoveNumberNo=Do not
 LizzieConfig.title.showMoveNumberAll=All
 LizzieConfig.title.showMoveNumberLast=Last
 LizzieConfig.title.showBlunderBar=Show Blunder Bar
+LizzieConfig.title.showBorder=Show Border
 LizzieConfig.title.dynamicWinrateGraphWidth=Dynamic Winrate Graph Width
 LizzieConfig.title.appendWinrateToComment=Append Winrate To Comment
 LizzieConfig.title.holdBestMovesToSgf=Hold Best Moves To Sgf

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -85,6 +85,7 @@ LizzieConfig.title.showMoveNumberNo=\u4E0D\u663E\u793A
 LizzieConfig.title.showMoveNumberAll=\u5168\u90E8
 LizzieConfig.title.showMoveNumberLast=\u6700\u540E
 LizzieConfig.title.showBlunderBar=\u663E\u793A\u80DC\u7387\u53D8\u5316\u6761
+LizzieConfig.title.showBorder=\u663E\u793A\u8FB9\u6846
 LizzieConfig.title.dynamicWinrateGraphWidth=\u52A8\u6001\u80DC\u7387\u9762\u677F\u5BBD\u5EA6
 LizzieConfig.title.appendWinrateToComment=\u5728\u8BC4\u8BBA\u4E2D\u9644\u52A0\u80DC\u7387
 LizzieConfig.title.holdBestMovesToSgf=\u4FDD\u6301\u9009\u70B9\u81F3\u68CB\u8C31


### PR DESCRIPTION
1. Allow user turn on/off the border
![image](https://user-images.githubusercontent.com/42595514/66696556-8b561180-ecff-11e9-8b8f-10130cd21ce4.png)

2. The board border is no longer supported, add another option if needed