### PR TITLE
Avoid empty config dialog and empty GTP console (#616)

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -222,7 +222,9 @@ public class ConfigDialog extends JDialog {
   public ConfigDialog() {
     setTitle(resourceBundle.getString("LizzieConfig.title.config"));
     setModalityType(ModalityType.APPLICATION_MODAL);
-    setType(Type.POPUP);
+    if (isWindows()) { // avoid suspicious behavior on Linux (#616)
+      setType(Type.POPUP);
+    }
     setBounds(100, 100, 661, 716);
     getContentPane().setLayout(new BorderLayout());
     JPanel buttonPane = new JPanel();

--- a/src/main/java/featurecat/lizzie/gui/GtpConsolePane.java
+++ b/src/main/java/featurecat/lizzie/gui/GtpConsolePane.java
@@ -82,7 +82,6 @@ public class GtpConsolePane extends JDialog {
     scrollPane.setViewportView(console);
     getRootPane().setBorder(BorderFactory.createEmptyBorder());
     getRootPane().setWindowDecorationStyle(JRootPane.PLAIN_DIALOG);
-    setVisible(true);
 
     txtCommand.addActionListener(e -> postCommand(e));
   }


### PR DESCRIPTION
I'm not sure whether this is a correct fix for #616. This PR also fixes another problem that is reported in the comments to #616: an empty GTP console (gray rectangle) is displayed even if I write `"print-comms": false` in config.txt.
