### PR TITLE
Fix: "Pondering on/off" was not updated by Analyze button

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/ToolBar.java
+++ b/src/main/java/featurecat/lizzie/gui/ToolBar.java
@@ -60,6 +60,7 @@ public class ToolBar extends JToolBar {
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
             Lizzie.leelaz.togglePonder();
+            Lizzie.frame.refresh();
           }
         });
     add(analyze);


### PR DESCRIPTION
If I click "Analyze" button in the toolbar when "Pondering on" is displayed, this text is not updated to "Pondering off" until I move the mouse cursor into the main board.
