### PR TITLE
Small sysout println changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.classpath
+.project
+.settings
+gtp.log
 persist.properties
 persist
 lizzie.properties

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -271,7 +271,7 @@ public class Config {
 
     gtpConsoleStyle = uiConfig.optString("gtp-console-style", defaultGtpConsoleStyle);
 
-    System.out.println(Locale.getDefault().getLanguage()); // todo add config option for language...
+    System.out.println("Setting default language:"+Locale.getDefault().getLanguage()); // todo add config option for language...
     setLanguage(Locale.getDefault().getLanguage());
   }
 

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -32,16 +32,17 @@ public class Lizzie {
     frame = config.panelUI ? new LizzieMain() : new LizzieFrame();
     gtpConsole = new GtpConsolePane(frame);
     gtpConsole.setVisible(config.leelazConfig.optBoolean("print-comms", false));
+    
     try {
       engineManager = new EngineManager(config);
-      if (mainArgs.length == 1) {
-        frame.loadFile(new File(mainArgs[0]));
-      } else if (config.config.getJSONObject("ui").getBoolean("resume-previous-game")) {
-        board.resumePreviousGame();
-      }
     } catch (IOException e) {
-      frame.openConfigDialog();
-      System.exit(1);
+        frame.openConfigDialog();
+    }
+
+    if (mainArgs.length == 1) {
+      frame.loadFile(new File(mainArgs[0]));
+    } else if (config.config.getJSONObject("ui").getBoolean("resume-previous-game")) {
+      board.resumePreviousGame();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -171,11 +171,11 @@ public class Leelaz {
 
     // run leelaz
     ProcessBuilder processBuilder = new ProcessBuilder(commands);
+    System.out.println("Starting engine with command:" +commands);
     // Commented for remote ssh
     //    processBuilder.directory(startfolder);
     processBuilder.redirectErrorStream(true);
     process = processBuilder.start();
-
     initializeStreams();
 
     // Send a name request to check if the engine is KataGo

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -1918,7 +1918,9 @@ public class ConfigDialog extends JDialog {
     int[] size = getBoardSize();
     Lizzie.board.reopen(size[0], size[1]);
     try {
-      Lizzie.engineManager.refresh();
+      //if (Lizzie.engineManager != null) {
+        Lizzie.engineManager.refresh();
+      //}
     } catch (JSONException e) {
       e.printStackTrace();
     } catch (IOException e) {

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -1820,7 +1820,7 @@ public class ConfigDialog extends JDialog {
               resourceBundle.getString("LizzieConfig.title.engine"), "exe", "bat", "sh");
       chooser.setFileFilter(filter);
     } else {
-      setVisible(false);
+      //setVisible(false);
     }
     chooser.setMultiSelectionEnabled(false);
     chooser.setDialogTitle(resourceBundle.getString("LizzieConfig.prompt.selectEngine"));


### PR DESCRIPTION
I noticed that lizzie prints out the language code on each startup which can be mysterious for the user. I changed the messaging there so that user would not be that confused about just seeing "en" for example.

Also I've noticed that most of the issues I have is that Lizzie cannot start an engine. I added a debug line to print out the command it is trying to execute. I'm sure this will help many people to debug the configuration of Lizzie.