### PR TITLE
Fix saveBackRouting skipping nodes

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -806,8 +806,11 @@ public class Board implements LeelazListener {
   /** Save the back routing from children */
   public void saveBackRouting(BoardHistoryNode node) {
     Optional<BoardHistoryNode> prev = node.previous();
-    prev.ifPresent(n -> n.setFromBackChildren(n.getVariations().indexOf(node)));
-    prev.ifPresent(n -> n.previous().ifPresent(p -> saveBackRouting(p)));
+    prev.ifPresent(
+        n -> {
+          n.setFromBackChildren(n.getVariations().indexOf(node));
+          saveBackRouting(n);
+        });
   }
 
   /** Restore move number by saved node */


### PR DESCRIPTION
`Board.saveBackRouting` is supposed to walk the list of `BoardHistoryNodes` from
the current position to the top of the tree, and at every node, set the
`fromBackChildren` of the previous `BoardHistoryNode` to the variation index
of the current node. However, due to a bug in `saveBackRouting`, half of the
nodes were being skipped in the process.

The effect of this is that when switching between different engines, the board
state could jump to a variation the user wasn't looking at previously. By
properly stepping through every node during `saveBackRouting`, switching between
engines always properly preserves the current variation.