### PR TITLE
Show GTP console during initial tuning of KataGo

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -294,6 +294,12 @@ public class Leelaz {
         } catch (NumberFormatException nfe) {
           dynamicOppKomi = Float.NaN;
         }
+      } else if (line.startsWith("Tuning")) {
+        // Show GTP console during initial tuning of KataGo
+        // to avoid long no-response
+        if (!Lizzie.gtpConsole.isVisible()) {
+          Lizzie.frame.toggleGtpConsole();
+        }
       } else if (line.equals("\n")) {
         // End of response
       } else if (line.startsWith("info")) {


### PR DESCRIPTION
How about showing GTP console during initial tuning of KataGo to avoid long no-response?

(cf. https://github.com/featurecat/lizzie/issues/633#issuecomment-573415262)
