### PR TITLE
Improve handicap support

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -260,7 +260,6 @@ public abstract class MainFrame extends JFrame {
       if (isHandicapGame && !playerIsBlack) {
         Lizzie.board.getHistory().getData().blackToPlay = false;
         Lizzie.leelaz.handicap(gameInfo.getHandicap());
-        //if (playerIsBlack) Lizzie.leelaz.genmove("W");
       } else if (!playerIsBlack) {
         Lizzie.leelaz.genmove("B");
       }

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -257,10 +257,10 @@ public abstract class MainFrame extends JFrame {
     boolean isHandicapGame = gameInfo.getHandicap() != 0;
     if (isNewGame) {
       Lizzie.board.getHistory().setGameInfo(gameInfo);
-      if (isHandicapGame) {
+      if (isHandicapGame && !playerIsBlack) {
         Lizzie.board.getHistory().getData().blackToPlay = false;
         Lizzie.leelaz.handicap(gameInfo.getHandicap());
-        if (playerIsBlack) Lizzie.leelaz.genmove("W");
+        //if (playerIsBlack) Lizzie.leelaz.genmove("W");
       } else if (!playerIsBlack) {
         Lizzie.leelaz.genmove("B");
       }


### PR DESCRIPTION
There's two issues with https://github.com/featurecat/lizzie/pull/554 unfortunately.

1. If the human wants a handicap vs Katago, Katago is placing the human's stones. This initial PR stops that behavior that.
2. When the human places a handicap stone (is playing black and received the handicap) then blackToPlay should remain black while the # of stones played in the history is less than the handicap.

I haven't figured out part 2 yet, perhaps someone with more Lizzie experience can do so?

A work around would be if the human is playing black, call fixed_handicap and have the engine place all the handicap stones and genmove("W"). That should avoid the hassles of supporting free handicap placement by the human, but it'd be nice to fully support it.