### PR TITLE
Commentpane to swing component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.classpath
+.project
+.settings
+gtp.log
 persist.properties
 persist
 lizzie.properties

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -271,7 +271,7 @@ public class Config {
 
     gtpConsoleStyle = uiConfig.optString("gtp-console-style", defaultGtpConsoleStyle);
 
-    System.out.println(Locale.getDefault().getLanguage()); // todo add config option for language...
+    System.out.println("Setting default language:"+Locale.getDefault().getLanguage()); // todo add config option for language...
     setLanguage(Locale.getDefault().getLanguage());
   }
 

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -271,7 +271,9 @@ public class Config {
 
     gtpConsoleStyle = uiConfig.optString("gtp-console-style", defaultGtpConsoleStyle);
 
-    System.out.println("Setting default language:"+Locale.getDefault().getLanguage()); // todo add config option for language...
+    System.out.println(
+        "Setting default language:"
+            + Locale.getDefault().getLanguage()); // todo add config option for language...
     setLanguage(Locale.getDefault().getLanguage());
   }
 

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -32,16 +32,17 @@ public class Lizzie {
     frame = config.panelUI ? new LizzieMain() : new LizzieFrame();
     gtpConsole = new GtpConsolePane(frame);
     gtpConsole.setVisible(config.leelazConfig.optBoolean("print-comms", false));
+    
     try {
       engineManager = new EngineManager(config);
-      if (mainArgs.length == 1) {
-        frame.loadFile(new File(mainArgs[0]));
-      } else if (config.config.getJSONObject("ui").getBoolean("resume-previous-game")) {
-        board.resumePreviousGame();
-      }
     } catch (IOException e) {
-      frame.openConfigDialog();
-      System.exit(1);
+        frame.openConfigDialog();
+    }
+
+    if (mainArgs.length == 1) {
+      frame.loadFile(new File(mainArgs[0]));
+    } else if (config.config.getJSONObject("ui").getBoolean("resume-previous-game")) {
+      board.resumePreviousGame();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -32,11 +32,11 @@ public class Lizzie {
     frame = config.panelUI ? new LizzieMain() : new LizzieFrame();
     gtpConsole = new GtpConsolePane(frame);
     gtpConsole.setVisible(config.leelazConfig.optBoolean("print-comms", false));
-    
+
     try {
       engineManager = new EngineManager(config);
     } catch (IOException e) {
-        frame.openConfigDialog();
+      frame.openConfigDialog();
     }
 
     if (mainArgs.length == 1) {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -171,7 +171,7 @@ public class Leelaz {
 
     // run leelaz
     ProcessBuilder processBuilder = new ProcessBuilder(commands);
-    System.out.println("Starting engine with command:" +commands);
+    System.out.println("Starting engine with command:" + commands);
     // Commented for remote ssh
     //    processBuilder.directory(startfolder);
     processBuilder.redirectErrorStream(true);
@@ -324,7 +324,7 @@ public class Leelaz {
             this.bestMoves = parseInfo(line.substring(5));
           }
           notifyBestMoveListeners();
-          Lizzie.frame.refresh(1);
+          Lizzie.frame.refresh(4);
           // don't follow the maxAnalyzeTime rule if we are in analysis mode
           if (System.currentTimeMillis() - startPonderTime > maxAnalyzeTimeMillis
               && !Lizzie.board.inAnalysisMode()) {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -171,11 +171,11 @@ public class Leelaz {
 
     // run leelaz
     ProcessBuilder processBuilder = new ProcessBuilder(commands);
+    System.out.println("Starting engine with command:" +commands);
     // Commented for remote ssh
     //    processBuilder.directory(startfolder);
     processBuilder.redirectErrorStream(true);
     process = processBuilder.start();
-
     initializeStreams();
 
     // Send a name request to check if the engine is KataGo

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -1918,7 +1918,9 @@ public class ConfigDialog extends JDialog {
     int[] size = getBoardSize();
     Lizzie.board.reopen(size[0], size[1]);
     try {
-      Lizzie.engineManager.refresh();
+      //if (Lizzie.engineManager != null) {
+        Lizzie.engineManager.refresh();
+      //}
     } catch (JSONException e) {
       e.printStackTrace();
     } catch (IOException e) {

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -1820,7 +1820,7 @@ public class ConfigDialog extends JDialog {
               resourceBundle.getString("LizzieConfig.title.engine"), "exe", "bat", "sh");
       chooser.setFileFilter(filter);
     } else {
-      setVisible(false);
+      //setVisible(false);
     }
     chooser.setMultiSelectionEnabled(false);
     chooser.setDialogTitle(resourceBundle.getString("LizzieConfig.prompt.selectEngine"));

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -1820,7 +1820,7 @@ public class ConfigDialog extends JDialog {
               resourceBundle.getString("LizzieConfig.title.engine"), "exe", "bat", "sh");
       chooser.setFileFilter(filter);
     } else {
-      //setVisible(false);
+      // setVisible(false);
     }
     chooser.setMultiSelectionEnabled(false);
     chooser.setDialogTitle(resourceBundle.getString("LizzieConfig.prompt.selectEngine"));
@@ -1918,9 +1918,9 @@ public class ConfigDialog extends JDialog {
     int[] size = getBoardSize();
     Lizzie.board.reopen(size[0], size[1]);
     try {
-      //if (Lizzie.engineManager != null) {
-        Lizzie.engineManager.refresh();
-      //}
+      // if (Lizzie.engineManager != null) {
+      Lizzie.engineManager.refresh();
+      // }
     } catch (JSONException e) {
       e.printStackTrace();
     } catch (IOException e) {

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -10,7 +10,6 @@ import java.awt.BorderLayout;
 import java.awt.FileDialog;
 import java.awt.Font;
 import java.awt.FontFormatException;
-import java.awt.Graphics;
 import java.awt.HeadlessException;
 import java.awt.LayoutManager;
 import java.awt.event.MouseWheelEvent;
@@ -97,22 +96,21 @@ public abstract class MainFrame extends JFrame {
   /**
    * Refresh
    *
-   * 
    * @param type: 0-All, 1-Only Board, 2-Invalid Layout, 3-All but okay not to repaint all the times
    */
   long prevTimeinMillis = System.currentTimeMillis();
+
   public void refresh(int type) {
     // we skip most of the repaints as info is coming in so quickly
     // that it does not add much value to show everything
     if (4 == type) {
       long timeInMillis = System.currentTimeMillis();
-      if ((timeInMillis-prevTimeinMillis) < 700) {
+      if ((timeInMillis - prevTimeinMillis) < 700) {
         return;
       }
       prevTimeinMillis = timeInMillis;
       repaint();
-    }
-    else {
+    } else {
       repaint();
     }
   }

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -10,6 +10,7 @@ import java.awt.BorderLayout;
 import java.awt.FileDialog;
 import java.awt.Font;
 import java.awt.FontFormatException;
+import java.awt.Graphics;
 import java.awt.HeadlessException;
 import java.awt.LayoutManager;
 import java.awt.event.MouseWheelEvent;
@@ -96,10 +97,24 @@ public abstract class MainFrame extends JFrame {
   /**
    * Refresh
    *
-   * @param type: 0-All, 1-Only Board, 2-Invalid Layout
+   * 
+   * @param type: 0-All, 1-Only Board, 2-Invalid Layout, 3-All but okay not to repaint all the times
    */
+  long prevTimeinMillis = System.currentTimeMillis();
   public void refresh(int type) {
-    repaint();
+    // we skip most of the repaints as info is coming in so quickly
+    // that it does not add much value to show everything
+    if (4 == type) {
+      long timeInMillis = System.currentTimeMillis();
+      if ((timeInMillis-prevTimeinMillis) < 700) {
+        return;
+      }
+      prevTimeinMillis = timeInMillis;
+      repaint();
+    }
+    else {
+      repaint();
+    }
   }
 
   public boolean isForceRefresh() {

--- a/src/main/java/featurecat/lizzie/gui/VariationTree.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTree.java
@@ -86,9 +86,7 @@ public class VariationTree {
     int diff = (DOT_DIAM - diam) / 2;
 
     if (calc) {
-      System.out.println("SEARCHING "+curposx+" "+posy);
       if (inNode(curposx + dotoffset, posy + dotoffset)) {
-        System.out.println("FOUND");
         return Optional.of(startNode);
       }
     } else if (lane > 0) {
@@ -307,11 +305,9 @@ public class VariationTree {
   }
 
   public void onClicked(int x, int y) {
-    System.out.println(x+" "+ y);
     if (area.contains(x, y)) {
       clickPoint.setLocation(x, y);
       Optional<BoardHistoryNode> node = draw(null, area.x, area.y, area.width, area.height, true);
-      System.out.println("found node"+node);
       node.ifPresent(n -> Lizzie.board.moveToAnyPosition(n));
     }
   }

--- a/src/main/java/featurecat/lizzie/gui/VariationTree.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTree.java
@@ -301,7 +301,7 @@ public class VariationTree {
   }
 
   public boolean inNode(int x, int y) {
-    return Math.abs(clickPoint.x - x) < XSPACING / 2 && Math.abs(clickPoint.y - y) < YSPACING / 2;
+    return Math.abs(clickPoint.x - x) < XSPACING / 2 && Math.abs(clickPoint.y - y) < YSPACING;
   }
 
   public void onClicked(int x, int y) {

--- a/src/main/java/featurecat/lizzie/gui/VariationTree.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTree.java
@@ -1,8 +1,5 @@
 package featurecat.lizzie.gui;
 
-import featurecat.lizzie.Lizzie;
-import featurecat.lizzie.rules.BoardHistoryNode;
-import featurecat.lizzie.util.Utils;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics;
@@ -11,6 +8,11 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Optional;
+
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.rules.BoardHistoryList;
+import featurecat.lizzie.rules.BoardHistoryNode;
+import featurecat.lizzie.util.Utils;
 
 public class VariationTree {
 
@@ -44,10 +46,12 @@ public class VariationTree {
       int variationNumber,
       boolean isMain,
       boolean calc) {
-    Optional<BoardHistoryNode> node = Optional.empty();
+    
     if (!calc) {
-      if (isMain) g.setColor(Color.white);
-      else g.setColor(Color.gray.brighter());
+      if (isMain)
+        g.setColor(Color.white);
+      else
+        g.setColor(Color.gray.brighter());
     }
 
     // Finds depth on leftmost variation of this tree
@@ -82,7 +86,9 @@ public class VariationTree {
     int diff = (DOT_DIAM - diam) / 2;
 
     if (calc) {
+      System.out.println("SEARCHING "+curposx+" "+posy);
       if (inNode(curposx + dotoffset, posy + dotoffset)) {
+        System.out.println("FOUND");
         return Optional.of(startNode);
       }
     } else if (lane > 0) {
@@ -221,7 +227,7 @@ public class VariationTree {
       }
       posy -= YSPACING;
     }
-    return node;
+    return Optional.empty();
   }
 
   public void draw(Graphics2D g, int posx, int posy, int width, int height) {
@@ -261,7 +267,8 @@ public class VariationTree {
     int xoffset = 30;
     laneUsageList.clear();
 
-    curMove = Lizzie.board.getHistory().getCurrentHistoryNode();
+    BoardHistoryList boardHistory = Lizzie.board.getHistory();
+    curMove = boardHistory.getCurrentHistoryNode();
 
     // Is current move a variation? If so, find top of variation
     BoardHistoryNode top = curMove.findTop();
@@ -300,9 +307,11 @@ public class VariationTree {
   }
 
   public void onClicked(int x, int y) {
+    System.out.println(x+" "+ y);
     if (area.contains(x, y)) {
       clickPoint.setLocation(x, y);
       Optional<BoardHistoryNode> node = draw(null, area.x, area.y, area.width, area.height, true);
+      System.out.println("found node"+node);
       node.ifPresent(n -> Lizzie.board.moveToAnyPosition(n));
     }
   }


### PR DESCRIPTION
I was bored yesterday and I was going through issues in Lizzie and I saw that wordwrap was requested for the comment pane in issue #676 

I jumped into the code and realised that all components are converted into graphics and then those are stitched together for the UI.

As a thought exercise I extracted the comment pane into a separate component, JTextArea. I also had to extract the tree but I still left that as a graphics component.

It could be a step forward to having Java components rather than just graphics.

Another big change in this pull request is I'm skipping a lot of repaints for Leelaz. I saw that the UI sluggish because painting was happening very often when the engine is providing all kind of info. As most of the info you can ignore (it does not matter if the scores change 10 times a second or 2 times) then I'm skipping repaints unless there 700ms has passed since the previous one.

I realise that this is not the best pull request as it is based on my working tree that has other fixes in 
it but I'm still submitting this as the component conversion can be taken separately if there is interest.

The same goes for the UI changes.