### PR TITLE
Maybe fix #707 (score/win-rate flips)

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -39,6 +39,7 @@ public class Leelaz {
   private int cmdNumber;
   private int currentCmdNum;
   private ArrayDeque<String> cmdQueue;
+  private boolean isModifyingBoard = false;
 
   private Process process;
 
@@ -305,7 +306,7 @@ public class Leelaz {
         switching = false;
         // Display engine command in the title
         Lizzie.frame.updateTitle();
-        if (isResponseUpToDate()) {
+        if (isAnalysisUpToDate()) {
           // This should not be stale data when the command number match
           if (isKataGo) {
             this.bestMoves = parseInfoKatago(line.substring(5));
@@ -535,6 +536,22 @@ public class Leelaz {
   private boolean isResponseUpToDate() {
     // Use >= instead of == for avoiding hang-up, though it cannot happen
     return currentCmdNum >= cmdNumber - 1;
+  }
+
+  private boolean isAnalysisUpToDate() {
+    return !isModifyingBoard && isResponseUpToDate();
+  }
+
+  public void beginModifyingBoard() {
+    synchronized (this) {
+      isModifyingBoard = true;
+    }
+  }
+
+  public void endModifyingBoard() {
+    synchronized (this) {
+      isModifyingBoard = false;
+    }
   }
 
   /**

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -501,6 +501,7 @@ public class Board implements LeelazListener {
           && !changeMove) {
         // this is the next coordinate in history. Just increment history so that we don't erase the
         // redo's
+        Lizzie.leelaz.beginModifyingBoard();
         history.next();
         // should be opposite from the bottom case
         if (Lizzie.frame.isPlayingAgainstLeelaz
@@ -510,6 +511,7 @@ public class Board implements LeelazListener {
         } else if (!Lizzie.frame.isPlayingAgainstLeelaz) {
           Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y));
         }
+        Lizzie.leelaz.endModifyingBoard();
         return;
       }
 
@@ -572,6 +574,7 @@ public class Board implements LeelazListener {
       if (isSuicidal > 0 || history.violatesKoRule(newState)) return;
 
       // update leelaz with board position
+      Lizzie.leelaz.beginModifyingBoard();
       if (Lizzie.frame.isPlayingAgainstLeelaz
           && Lizzie.frame.playerIsBlack == getData().blackToPlay) {
         Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y));
@@ -582,6 +585,7 @@ public class Board implements LeelazListener {
 
       // update history with this coordinate
       history.addOrGoto(newState, newBranch, changeMove);
+      Lizzie.leelaz.endModifyingBoard();
 
       Lizzie.frame.refresh();
     }
@@ -759,6 +763,7 @@ public class Board implements LeelazListener {
     }
     synchronized (this) {
       updateWinrate();
+      Lizzie.leelaz.beginModifyingBoard();
       if (history.next().isPresent()) {
         // update leelaz board position, before updating to next node
         Optional<int[]> lastMoveOpt = history.getData().lastMove;
@@ -770,8 +775,10 @@ public class Board implements LeelazListener {
           Lizzie.leelaz.playMove(history.getLastMoveColor(), "pass");
         }
         Lizzie.frame.refresh();
+        Lizzie.leelaz.endModifyingBoard();
         return true;
       }
+      Lizzie.leelaz.endModifyingBoard();
       return false;
     }
   }
@@ -1114,11 +1121,14 @@ public class Board implements LeelazListener {
     synchronized (this) {
       if (inScoreMode()) setScoreMode(false);
       updateWinrate();
+      Lizzie.leelaz.beginModifyingBoard();
       if (history.previous().isPresent()) {
         Lizzie.leelaz.undo();
         Lizzie.frame.refresh();
+        Lizzie.leelaz.endModifyingBoard();
         return true;
       }
+      Lizzie.leelaz.endModifyingBoard();
       return false;
     }
   }


### PR DESCRIPTION
This patch may fix #707 (score/win-rate flips) if it is due to a race condition as @lightvector guessed in https://github.com/lightvector/KataGo/issues/231 . I cannot check it by myself since I cannot reproduce the issue.

Lizzie already skips `parseInfo()` unless the ID of the last-received GTP response is equal to that of the last-sent GTP command in Leelaz.java. But there may be a small chance that `parseInfo()` is called between `history.next()` and `Lizzie.leelaz.playMove()` in Board.java, for example.
