### PR TITLE
bump version to 0.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>featurecat</groupId>
     <artifactId>lizzie</artifactId>
-    <version>0.7.2</version>
+    <version>0.7.3</version>
 
     <properties>
         <!-- Prevent warning: "[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!"-->

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -20,7 +20,7 @@ public class Lizzie {
   public static GtpConsolePane gtpConsole;
   public static Board board;
   public static Leelaz leelaz;
-  public static String lizzieVersion = "0.7.2";
+  public static String lizzieVersion = "0.7.3";
   private static String[] mainArgs;
   public static EngineManager engineManager;
 


### PR DESCRIPTION
The version number in pom.xml and Lizzie.java wasn't bumped from 0.7.2 when 0.7.3 was released, so this small PR fixes that. 