### PR TITLE
Fix #727 (winrate graph for LCB)

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1020,8 +1020,8 @@ public class LizzieFrame extends MainFrame {
 
     if (validWinrate || validLastWinrate) {
       int maxBarwidth = (int) (width);
-      int barWidthB = (int) (blackWR * maxBarwidth / 100);
-      int barWidthW = (int) (whiteWR * maxBarwidth / 100);
+      int barWidthB = (int) (Math.max(0, Math.min(blackWR, 100)) * maxBarwidth / 100);
+      int barWidthW = (int) (Math.max(0, Math.min(whiteWR, 100)) * maxBarwidth / 100);
       int barPosY = posY + height / 3;
       int barPosxB = (int) (posX);
       int barPosxW = barPosxB + barWidthB;

--- a/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
@@ -163,9 +163,7 @@ public class WinrateGraph {
         g.setStroke(previousStroke);
       }
       if (playouts > 0) {
-        if (wr < 0) {
-          wr = 100 - lastWr;
-        } else if (!node.getData().blackToPlay) {
+        if (!node.getData().blackToPlay) {
           wr = 100 - wr;
         }
         if (Lizzie.frame.isPlayingAgainstLeelaz

--- a/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
@@ -339,7 +339,7 @@ public class WinrateGraph {
       double r = 0.5 + handicap / (2 * maxHandicap);
       return Math.max(0, Math.min(r, 1)) * 100;
     } else {
-      return winrate;
+      return Math.max(0, Math.min(winrate, 100));
     }
   }
 


### PR DESCRIPTION
Fix #727

(notes)
In Lizzie, negative winrates are internally used for "no data" (e.g. place() in Board.java and getWinrateStats() in Leelaz.java). So `wr = 100 - lastWr;` was necessary in the initial version of WinrateGraph.java (82357ee). It seems needless after 570ac36 as it is inside `if (playouts > 0) {`.
