### PR TITLE
Fix #729 (scoreMean & scoreStdev)

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -912,6 +912,7 @@ public class LizzieFrame extends MainFrame {
     double curWR = stats.maxWinrate; // winrate on this move
     double curSM = stats.maxScoreMean; // mean score on this move
     boolean validWinrate = (stats.totalPlayouts > 0); // and whether it was actually calculated
+    boolean validScore = validWinrate;
     if (!validWinrate) {
       curWR = Lizzie.board.getHistory().getData().winrate;
       validWinrate = Lizzie.board.getHistory().getData().getPlayouts() > 0;
@@ -967,7 +968,7 @@ public class LizzieFrame extends MainFrame {
     setPanelFont(g, (int) (min(width, height) * 0.2));
 
     String text = "";
-    if (Lizzie.leelaz.isKataGo) {
+    if (Lizzie.leelaz.isKataGo && validScore) {
       double score = Lizzie.leelaz.scoreMean;
       if (Lizzie.board.getHistory().isBlacksTurn()) {
         if (Lizzie.config.showKataGoBoardScoreMean) {

--- a/src/main/java/featurecat/lizzie/gui/WinratePane.java
+++ b/src/main/java/featurecat/lizzie/gui/WinratePane.java
@@ -123,6 +123,7 @@ public class WinratePane extends LizziePane {
     Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
     double curWR = stats.maxWinrate; // winrate on this move
     boolean validWinrate = (stats.totalPlayouts > 0); // and whether it was actually calculated
+    boolean validScore = validWinrate;
     if (Lizzie.frame.isPlayingAgainstLeelaz
         && Lizzie.frame.playerIsBlack == !Lizzie.board.getHistory().getData().blackToPlay) {
       validWinrate = false;
@@ -172,7 +173,7 @@ public class WinratePane extends LizziePane {
     setPanelFont(g, (int) (min(width, height) * 0.2));
 
     String text = "";
-    if (Lizzie.leelaz.isKataGo) {
+    if (Lizzie.leelaz.isKataGo && validScore) {
       double score = Lizzie.leelaz.scoreMean;
       if (Lizzie.board.getHistory().isBlacksTurn()) {
         if (Lizzie.config.showKataGoBoardScoreMean) {


### PR DESCRIPTION
This patch simply hides invalid scoreMean and scoreStdev as a quick fix of #729. Of course it is better to show saved values of them instead if we have enough motivation...
