### PR TITLE
Fix #745 (NPE after initial config)

### DIFF
--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -32,6 +32,10 @@ public class Lizzie {
     frame = config.panelUI ? new LizzieMain() : new LizzieFrame();
     gtpConsole = new GtpConsolePane(frame);
     gtpConsole.setVisible(config.leelazConfig.optBoolean("print-comms", false));
+    initializeEngineManager();
+  }
+
+  public static void initializeEngineManager() {
     try {
       engineManager = new EngineManager(config);
       if (mainArgs.length == 1) {
@@ -41,6 +45,7 @@ public class Lizzie {
       }
     } catch (IOException e) {
       frame.openConfigDialog();
+      JOptionPane.showMessageDialog(frame, "Please restart Lizzie to apply changes.");
       System.exit(1);
     }
   }

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -1917,6 +1917,9 @@ public class ConfigDialog extends JDialog {
   private void applyChange() {
     int[] size = getBoardSize();
     Lizzie.board.reopen(size[0], size[1]);
+    if (Lizzie.engineManager == null) {
+      Lizzie.initializeEngineManager();
+    }
     try {
       Lizzie.engineManager.refresh();
     } catch (JSONException e) {


### PR DESCRIPTION
Fix #745. I also added a message dialog before the silent exit. (I'm not sure why this `exit` is needed after the initial configuration.)
