### PR TITLE
Show error dialog for typical engine troubles

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -476,6 +476,9 @@ public class Leelaz {
       // this line will be reached when Leelaz shuts down
       System.out.println("Engine process ended.");
       if (!isQuittingNormally) {
+        if (!Lizzie.gtpConsole.isVisible()) {
+          Lizzie.frame.toggleGtpConsole();
+        }
         alertEngineDown(
             "Engine process ended unintentionally for some reason.\nYou may find more information in GTP console.");
       }

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -175,7 +175,16 @@ public class Leelaz {
     // Commented for remote ssh
     //    processBuilder.directory(startfolder);
     processBuilder.redirectErrorStream(true);
-    process = processBuilder.start();
+    try {
+      process = processBuilder.start();
+    } catch (IOException e) {
+      JOptionPane.showMessageDialog(
+          Lizzie.frame,
+          "Failed to start the engine.",
+          "Lizzie - Error!",
+          JOptionPane.ERROR_MESSAGE);
+      throw e;
+    }
 
     initializeStreams();
 

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -81,6 +81,7 @@ public class Leelaz {
   private int currentEngineN = -1;
   private ScheduledExecutorService executor;
   private boolean isQuittingNormally = false;
+  private boolean isDown = false;
 
   // dynamic komi and opponent komi as reported by dynamic-komi version of leelaz
   private float dynamicKomi = Float.NaN;
@@ -138,6 +139,7 @@ public class Leelaz {
     isLoaded = false;
     isKataGo = false;
     isQuittingNormally = false;
+    isDown = false;
     bestMoves = new ArrayList<>();
     Lizzie.board.getData().tryToClearBestMoves();
 
@@ -183,10 +185,8 @@ public class Leelaz {
       String err = e.getLocalizedMessage();
       String message =
           String.format(
-              "Failed to start the engine.\n\nError: %s\nEngine command: %s",
-              (err == null) ? "(No message)" : err, engineCommand);
-      JOptionPane.showMessageDialog(
-          Lizzie.frame, message, "Lizzie - Error!", JOptionPane.ERROR_MESSAGE);
+              "Failed to start the engine.\n\nError: %s", (err == null) ? "(No message)" : err);
+      alertEngineDown(message);
       throw e;
     }
 
@@ -227,6 +227,13 @@ public class Leelaz {
     startEngine();
     //    currentEngineN = index;
     togglePonder();
+  }
+
+  private void alertEngineDown(String message) {
+    isDown = true;
+    String displayedMessage = String.format("%s\n\nEngine command: %s", message, engineCommand);
+    JOptionPane.showMessageDialog(
+        Lizzie.frame, displayedMessage, "Lizzie - Error!", JOptionPane.ERROR_MESSAGE);
   }
 
   public void normalQuit() {
@@ -469,12 +476,8 @@ public class Leelaz {
       // this line will be reached when Leelaz shuts down
       System.out.println("Engine process ended.");
       if (!isQuittingNormally) {
-        String message =
-            String.format(
-                "Engine process ended unintentionally for some reason.\n\nEngine command: %s",
-                engineCommand);
-        JOptionPane.showMessageDialog(
-            Lizzie.frame, message, "Lizzie - Error!", JOptionPane.ERROR_MESSAGE);
+        alertEngineDown(
+            "Engine process ended unintentionally for some reason.\nYou may find more information in GTP console.");
       }
 
       shutdown();
@@ -950,6 +953,10 @@ public class Leelaz {
       }
     }
     return isLoaded;
+  }
+
+  public boolean isDown() {
+    return isDown;
   }
 
   public boolean supportScoremean() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -178,11 +178,13 @@ public class Leelaz {
     try {
       process = processBuilder.start();
     } catch (IOException e) {
+      String err = e.getLocalizedMessage();
+      String message =
+          String.format(
+              "Failed to start the engine.\n\nError: %s\nEngine command: %s",
+              (err == null) ? "(No message)" : err, engineCommand);
       JOptionPane.showMessageDialog(
-          Lizzie.frame,
-          "Failed to start the engine.",
-          "Lizzie - Error!",
-          JOptionPane.ERROR_MESSAGE);
+          Lizzie.frame, message, "Lizzie - Error!", JOptionPane.ERROR_MESSAGE);
       throw e;
     }
 

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -231,6 +231,7 @@ public class Leelaz {
 
   private void alertEngineDown(String message) {
     isDown = true;
+    Lizzie.frame.refresh();
     String displayedMessage = String.format("%s\n\nEngine command: %s", message, engineCommand);
     JOptionPane.showMessageDialog(
         Lizzie.frame, displayedMessage, "Lizzie - Error!", JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -80,6 +80,7 @@ public class Leelaz {
   private boolean switching = false;
   private int currentEngineN = -1;
   private ScheduledExecutorService executor;
+  private boolean isQuittingNormally = false;
 
   // dynamic komi and opponent komi as reported by dynamic-komi version of leelaz
   private float dynamicKomi = Float.NaN;
@@ -136,6 +137,7 @@ public class Leelaz {
 
     isLoaded = false;
     isKataGo = false;
+    isQuittingNormally = false;
     bestMoves = new ArrayList<>();
     Lizzie.board.getData().tryToClearBestMoves();
 
@@ -228,6 +230,7 @@ public class Leelaz {
   }
 
   public void normalQuit() {
+    isQuittingNormally = true;
     sendCommand("quit");
     executor.shutdown();
     try {
@@ -465,6 +468,14 @@ public class Leelaz {
       }
       // this line will be reached when Leelaz shuts down
       System.out.println("Engine process ended.");
+      if (!isQuittingNormally) {
+        String message =
+            String.format(
+                "Engine process ended unintentionally for some reason.\n\nEngine command: %s",
+                engineCommand);
+        JOptionPane.showMessageDialog(
+            Lizzie.frame, message, "Lizzie - Error!", JOptionPane.ERROR_MESSAGE);
+      }
 
       shutdown();
       // Do no exit for switching weights

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -667,11 +667,7 @@ public class LizzieFrame extends MainFrame {
           }
         }
       } else if (Lizzie.config.showStatus) {
-        String loadingText =
-            (Lizzie.leelaz != null) && Lizzie.leelaz.isDown()
-                ? "Engine is down."
-                : resourceBundle.getString("LizzieFrame.display.loading");
-        drawPonderingState(g, loadingText, loadingX, loadingY, loadingSize);
+        drawPonderingState(g, loadingText(), loadingX, loadingY, loadingSize);
       }
 
       if (Lizzie.config.showCaptured) drawCaptured(g, capx, capy, capw, caph);

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -667,7 +667,10 @@ public class LizzieFrame extends MainFrame {
           }
         }
       } else if (Lizzie.config.showStatus) {
-        String loadingText = resourceBundle.getString("LizzieFrame.display.loading");
+        String loadingText =
+            (Lizzie.leelaz != null) && Lizzie.leelaz.isDown()
+                ? "Engine is down."
+                : resourceBundle.getString("LizzieFrame.display.loading");
         drawPonderingState(g, loadingText, loadingX, loadingY, loadingSize);
       }
 

--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -168,7 +168,10 @@ public class LizzieMain extends MainFrame {
                       bsGraphics, dynamicKomi.get(), dynamicKomiX, dynamicKomiY, dynamicKomiSize);
                 }
               } else if (Lizzie.config.showStatus) {
-                String loadingText = resourceBundle.getString("LizzieFrame.display.loading");
+                String loadingText =
+                    (Lizzie.leelaz != null) && Lizzie.leelaz.isDown()
+                        ? "Engine is down."
+                        : resourceBundle.getString("LizzieFrame.display.loading");
                 drawPonderingState(bsGraphics, loadingText, loadingX, loadingY, loadingSize);
               }
             }

--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -168,11 +168,7 @@ public class LizzieMain extends MainFrame {
                       bsGraphics, dynamicKomi.get(), dynamicKomiX, dynamicKomiY, dynamicKomiSize);
                 }
               } else if (Lizzie.config.showStatus) {
-                String loadingText =
-                    (Lizzie.leelaz != null) && Lizzie.leelaz.isDown()
-                        ? "Engine is down."
-                        : resourceBundle.getString("LizzieFrame.display.loading");
-                drawPonderingState(bsGraphics, loadingText, loadingX, loadingY, loadingSize);
+                drawPonderingState(bsGraphics, loadingText(), loadingX, loadingY, loadingSize);
               }
             }
           }

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -355,6 +355,12 @@ public abstract class MainFrame extends JFrame {
     }
   }
 
+  protected String loadingText() {
+    return (Lizzie.leelaz != null) && Lizzie.leelaz.isDown()
+        ? "Engine is down."
+        : resourceBundle.getString("LizzieFrame.display.loading");
+  }
+
   public void toggleEstimateByZen() {
     if (isEstimating) {
       noEstimateByZen(true);


### PR DESCRIPTION
Many many users are confused by the misleading message "Engine is loading...". It will be better to show an error dialog immediately when Lizzie failed to start the engine, at least.
