### PR TITLE
Avoid infinite loop in switchEngine

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -217,15 +217,25 @@ public class Leelaz {
   }
 
   public void normalQuit() {
+    final int MAX_TRIALS = 5;
     sendCommand("quit");
     executor.shutdown();
     try {
-      while (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+      for (int i = 0; i < MAX_TRIALS; i++) {
+        if (executor.awaitTermination(1, TimeUnit.SECONDS)) {
+          break;
+        }
+        System.out.printf("Waiting for shutdown of engine... (%d)\n", i + 1);
         executor.shutdownNow();
       }
-      if (executor.awaitTermination(1, TimeUnit.SECONDS)) {
-        shutdown();
+      if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+        JOptionPane.showMessageDialog(
+            Lizzie.frame,
+            "Engine does not close its pipe after GTP command 'quit'.",
+            "Lizzie - Error!",
+            JOptionPane.ERROR_MESSAGE);
       }
+      shutdown();
     } catch (InterruptedException e) {
       executor.shutdownNow();
       Thread.currentThread().interrupt();


### PR DESCRIPTION
Lizzie can freeze in switchEngine if the engine does not close its pipe after the GTP command "quit" for some reason. I noticed this when I tried a fake engine for experiments. I'm afraid this may occur when users write their scripts for cloud engines.

Here is a simple example of an engine command (for Linux). This engine works. But Lizzie freezes when the engine is switched to another one.

~~~
sh -c "cat | ./leelaz -g -w network.gz"
~~~

Anyway, infinite loop with no response is a bad idea. So this patch introduces `MAX_TRIALS` to avoid it.
