### PR TITLE
Accelerate loading of large SGF

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -58,6 +58,9 @@ public class Leelaz {
   private boolean isPondering;
   private long startPonderTime;
 
+  // enable temporary detaching for efficiency
+  public boolean isAttached = true;
+
   // fixed_handicap
   public boolean isSettingHandicap = false;
 
@@ -559,6 +562,9 @@ public class Leelaz {
    * @param move coordinate of the coordinate
    */
   public void playMove(Stone color, String move) {
+    if (!isAttached) {
+      return;
+    }
     synchronized (this) {
       String colorString;
       switch (color) {
@@ -646,6 +652,9 @@ public class Leelaz {
   }
 
   public void undo() {
+    if (!isAttached) {
+      return;
+    }
     synchronized (this) {
       sendCommand("undo");
       bestMoves = new ArrayList<>();

--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -121,7 +121,10 @@ public class SGFParser {
       Lizzie.leelaz.supportScoremean = false;
     }
 
+    // Detach engine for avoiding useless "play" and "undo" (#752).
+    Lizzie.leelaz.isAttached = false;
     parseValue(value, null, false);
+    Lizzie.leelaz.isAttached = true;
 
     return true;
   }


### PR DESCRIPTION
ref. https://github.com/featurecat/lizzie/issues/752#issuecomment-695796094

Summary:
Lizzie sends play/undo commands to the engine even when it builds only internal game tree. Besides #752, this makes loading of large SGF too slow. The present PR stops these useless play/undo in SGF loading. Though this PR is not a "fix" of #752, it may be useful as acceleration of loading.
