### PR TITLE
Record startup log for #756 even when printCommunication is not set

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -280,7 +280,7 @@ public class Leelaz {
    */
   private void parseLine(String line) {
     synchronized (this) {
-      if (printCommunication || gtpConsole) {
+      if (printCommunication || gtpConsole || !isLoaded) {
         Lizzie.gtpConsole.addLine(line);
       }
       if (line.startsWith("komi=")) {


### PR DESCRIPTION
This will be useful for diagnosis of engine troubles by beginners (ref. #756).