### PR TITLE
Correct inconsistent indents

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/GtpConsolePane.java
+++ b/src/main/java/featurecat/lizzie/gui/GtpConsolePane.java
@@ -137,8 +137,8 @@ public class GtpConsolePane extends JDialog {
 
   private void removeOldText() {
     Element body =
-            htmlDoc.getElement(
-                    htmlDoc.getDefaultRootElement(), StyleConstants.NameAttribute, HTML.Tag.BODY);
+        htmlDoc.getElement(
+            htmlDoc.getDefaultRootElement(), StyleConstants.NameAttribute, HTML.Tag.BODY);
     while (htmlDoc.getLength() > MAX_HTML_LENGTH) {
       ElementIterator it = new ElementIterator(body);
       it.first();


### PR DESCRIPTION
It is annoying that `mvn package` modifies indents of GtpConsolePane.java every time. I will be glad if @featurecat merges this PR into master soon for comfortable developments.